### PR TITLE
Add blog link to Auto-anonymize 

### DIFF
--- a/gretel/gc-auto_anonymize_dataset/manifest.json
+++ b/gretel/gc-auto_anonymize_dataset/manifest.json
@@ -1,8 +1,9 @@
 {
     "name": "Auto-anonymize production datasets for development",
     "description": "Build a data pipeline that will auto-anonymize datasets using Gretel's data catalog and transformation features.",
-    "tags": ["pii-detection", "anonymization", "transformers", "dev", "staging"],
+    "tags": ["pii-detection", "anonymization", "transformers"],
     "sample_data_key": "bike-customer-orders",
+    "blog_url": "https://gretel.ai/blog/auto-anonymize-production-datasets-for-development",
     "language": "python",
     "featured": true
 }


### PR DESCRIPTION
- Adds a link to Drew's blog post
- Removed `dev` and `staging` tags to be more concise. When we have proper tagging it may make sense to add them again but for now 2-3 tags is recommended :)