### PR TITLE
Optimize low-record-count config

### DIFF
--- a/config_templates/gretel/synthetics/low-record-count.yml
+++ b/config_templates/gretel/synthetics/low-record-count.yml
@@ -35,6 +35,9 @@ models:
       validators:
         in_set_count: 10
         pattern_count: 10
+      privacy_filters:
+        outliers: null
+        similarity: null
       generate:
         num_records: 1000
         max_invalid: 1000

--- a/config_templates/gretel/synthetics/low-record-count.yml
+++ b/config_templates/gretel/synthetics/low-record-count.yml
@@ -18,13 +18,23 @@ schema_version: 1.0
 
 models:
   - synthetics:
-      data_source: "__tmp__"
+      data_source: __tmp__
       params:
-        epochs: 100
+        epochs: 300
         batch_size: 1
         vocab_size: 0
-        learning_rate: .001
+        reset_states: False
+        learning_rate: 0.001
         rnn_units: 64
-      privacy_filters:
-        outliers: null
-        similarity: null
+        dropout_rate: 0.2
+        overwrite: True
+        early_stopping: True
+        gen_temp: 1.0
+        predict_batch_size: 1
+        validation_split: False
+      validators:
+        in_set_count: 10
+        pattern_count: 10
+      generate:
+        num_records: 1000
+        max_invalid: 1000


### PR DESCRIPTION
Disable validation split for low record count examples. From customer feedback, these files can be less than 100 lines and would not want to lose 20% for validation. Early stoppig still enabled. Also moving predict batch size to 1. While this results in a reduction in speed with generation, it enables a more realistic recreation of the original data semantics.