### PR TITLE
Add NLP blueprint for classifying freetext

### DIFF
--- a/docs/notebooks/classify_freetext_with_nlp.ipynb
+++ b/docs/notebooks/classify_freetext_with_nlp.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -Uqq git+https://github.com/gretelai/gretel-python-client.git spacy datasets"
+    "!pip install -Uqq gretel-client spacy datasets"
    ]
   },
   {
@@ -58,7 +58,7 @@
     "configure_session(\n",
     "    ClientConfig(\n",
     "        api_key=getpass(prompt=\"Enter Gretel API key\"),\n",
-    "        endpoint=\"https://api-dev.gretel.cloud\",\n",
+    "        endpoint=\"https://api.gretel.cloud\",\n",
     "    )\n",
     ")"
    ]
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "source_dataset = datasets.load_dataset(\"aeslc\")\n",
-    "source_df = pd.DataFrame(source_dataset[\"train\"]).sample(n=300, random_state=99)\n",
+    "source_df = pd.DataFrame(source_dataset[\"train\"]).sample(n=10000, random_state=99)\n",
     "source_df.to_csv(dataset_file_path, index=False)"
    ]
   },
@@ -281,10 +281,10 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "99ae99e64a5044a23ab6f5c27840d3e4841b27c6738155634dd09171cdfbb32f"
+   "hash": "c75c16813cbc397c72b905dbcc7225ac3e9db4701ee07b7887dce2bbda1e49e9"
   },
   "kernelspec": {
-   "display_name": "Python 3.7.9 64-bit ('g': virtualenv)",
+   "display_name": "Python 3.9.6 64-bit ('blueprints': virtualenv)",
    "name": "python3"
   },
   "language_info": {
@@ -297,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This adds a notebook for classifying free text using NLP via the `use_nlp` config flag. While the focus of the notebook is classification, there is some information for running a similar pipeline using transforms.

TODO before merging
- [x] Switch dev to prod api
- [x] Pip install from stable instead of main