### PR TITLE
Update default to turn off NLP

### DIFF
--- a/config_templates/gretel/classify/README.md
+++ b/config_templates/gretel/classify/README.md
@@ -9,7 +9,8 @@ Templates can be downloaded and modified for use with Gretel classify APIs, or i
 
  | template_name      | description |
  | ----------- |  ----------- |
- |`default`| This template contains a simple policy to identify commonly found personally identifiable information (PII). NLP is turned on to improve detection of person name and location data in unstructured text fields. This is the default config file provided in the Gretel console.|
- |`classify-pii-nlp-off`| This template contains the same policy as `classify-pii-nlp-on` but has NLP turned off to improve performance. Use this template for detecting common PII fields in large datasets.|
+ |`default`| This template contains a simple policy to identify commonly found personally identifiable information (PII). This is the default config file provided in the Gretel console.|
+ |`classify-pii-nlp-on`| This template contains the same policy as `default`. NLP is turned on to improve detection of person name and location data in unstructured text fields.|
+ |`classify-pii-nlp-off`| This template contains the same policy as `classify-pii-nlp-on` but has NLP turned off to improve performance. Use this template for detecting common PII fields in large datasets. Currently, this temmplate is the same as `default`, but will eventually be modified.|
  |`classify-pii-regex`| An example of using label_predictors and regular expressions to define custom predictors.|
  |`classify-all-entities`| Label all supported info types in your data. Warning! Performance could be slow for this model, depending on the amount of data being processed.|

--- a/config_templates/gretel/classify/classify-nlp-on.yml
+++ b/config_templates/gretel/classify/classify-nlp-on.yml
@@ -4,13 +4,16 @@
 # Use optional label_predictors and regular expressions to define custom predictors 
 # See https://docs.gretel.ai/classify/classify-model-configuration
 
+# NLP is turned on using "use_nlp: true" to provide better person name and 
+# location detection. Set to false if you're experiencing performance issues
+# https://docs.gretel.ai/classify/classify-model-configuration#classifying-data-using-nlp
 
 schema_version: "1.0"
-name: "classify-default"
+name: "classify-pii-nlp-on"
 models:
   - classify:
       data_source: "_"
-      use_nlp: false
+      use_nlp: true
       labels:
         - person_name
         - credit_card_number


### PR DESCRIPTION
NLP is creating false positives when used with the bike sales sample dataset. Turning it off to improve the experience for first time console users.