### PR TITLE
update pub key from nvidia repo

### DIFF
--- a/utils/gpu_docker_setup.sh
+++ b/utils/gpu_docker_setup.sh
@@ -5,7 +5,7 @@ if [[ $(lsb_release -rs) == "18.04" ]]; then
     # NVIDIA Google Cloud VM Ubuntu 18.04
     curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
     sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-    sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+    sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
     sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
     sudo apt install -y cuda
 


### PR DESCRIPTION
the pub key for pulling from the nvidia repo has been updated which currently breaks this script. 
Updated the key and tested it successfully on a g4dn.xlarge with Ubuntu 18.04