### PR TITLE
INT-469: Create a static service deployment for console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 .DS_Store
 .idea/
 .vscode/
+.vercel

--- a/build.js
+++ b/build.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const path = require("path");
+
+async function* walk(dir) {
+  for await (const d of await fs.promises.opendir(dir)) {
+    const entry = path.join(dir, d.name);
+    if (d.isDirectory()) yield* walk(entry);
+    else if (d.isFile()) yield entry;
+  }
+}
+
+// Then, use it with a simple async for loop
+async function main() {
+  const files = [];
+  for await (const p of walk("config_templates")) {
+    if (/\.ya?ml$/.test(p)) files.push(p);
+  }
+
+  console.log(JSON.stringify({ files }));
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "gretel-blueprints",
+  "version": "1.0.0",
+  "repository": "git@github.com:gretelai/gretel-blueprints.git",
+  "author": "",
+  "license": "MIT",
+  "scripts": {
+    "build": "node build.js > manifest.json"
+  }
+}


### PR DESCRIPTION
This script creates a manifest file that can be consumed by console easier than using the github api.

```json
{
  "files": [
    "config_templates/gretel/classify/classify-all-entities.yml",
    "config_templates/gretel/classify/default.yml",
    "config_templates/gretel/classify/classify-pii-nlp-off.yml",
    "config_templates/gretel/classify/classify-pii-regex.yml",
    "config_templates/gretel/classify/classify-pii-nlp-on.yml",
    "config_templates/gretel/synthetics/mostly-numeric-data.yml",
    "config_templates/gretel/synthetics/low-record-count.yml",
    "config_templates/gretel/synthetics/default.yml",
    "config_templates/gretel/synthetics/high-record-count.yml",
    "config_templates/gretel/synthetics/ctgan.yml",
    "config_templates/gretel/synthetics/differential-privacy.yml",
    "config_templates/gretel/synthetics/high-field-count.yml",
    "config_templates/gretel/synthetics/complex-or-free-text.yml",
    "config_templates/gretel/evaluate/default.yml",
    "config_templates/gretel/transform/default.yml",
    "config_templates/gretel/transform/redact-pii-regex.yml",
    "config_templates/gretel/transform/redact-pii-nlp-off.yml"
  ]
}
```