### PR TITLE
[PROD-140] Better inline report rendering for local notebooks.

### DIFF
--- a/docs/notebooks/create_synthetic_data_from_a_dataframe_or_csv.ipynb
+++ b/docs/notebooks/create_synthetic_data_from_a_dataframe_or_csv.ipynb
@@ -185,7 +185,7 @@
     "import IPython\n",
     "from smart_open import open\n",
     "\n",
-    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read())\n"
+    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read(), metadata=dict(isolated=True))\n"
    ]
   },
   {

--- a/docs/notebooks/evaluate/generate_quality_report_with_evaluate.ipynb
+++ b/docs/notebooks/evaluate/generate_quality_report_with_evaluate.ipynb
@@ -183,9 +183,8 @@
       "outputs": [],
       "source": [
         "import IPython\n",
-        "from smart_open import open\n",
         "\n",
-        "IPython.display.HTML(report.as_html)"
+        "IPython.display.HTML(report.as_html, metadata=dict(isolated=True))"
       ]
     },
     {

--- a/docs/notebooks/local_synthetics.ipynb
+++ b/docs/notebooks/local_synthetics.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "import IPython\n",
     "\n",
-    "IPython.display.HTML(data=open(\"tmp/report.html.gz\").read())\n"
+    "IPython.display.HTML(data=open(\"tmp/report.html.gz\").read(), metadata=dict(isolated=True))\n"
    ]
   },
   {

--- a/docs/notebooks/retain_values_with_conditional_data_generation.ipynb
+++ b/docs/notebooks/retain_values_with_conditional_data_generation.ipynb
@@ -130,7 +130,7 @@
     "import IPython\n",
     "from smart_open import open\n",
     "\n",
-    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read())\n"
+    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read(), metadata=dict(isolated=True))\n"
    ]
   },
   {

--- a/docs/notebooks/synthetic_data_walkthrough.ipynb
+++ b/docs/notebooks/synthetic_data_walkthrough.ipynb
@@ -232,7 +232,7 @@
     "import IPython\n",
     "from smart_open import open\n",
     "\n",
-    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read())\n"
+    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read(), metadata=dict(isolated=True))\n"
    ]
   },
   {

--- a/docs/notebooks/time_series_generation_poc.ipynb
+++ b/docs/notebooks/time_series_generation_poc.ipynb
@@ -306,7 +306,7 @@
     "import IPython\n",
     "from smart_open import open\n",
     "\n",
-    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read())\n"
+    "IPython.display.HTML(data=open(model.get_artifact_link(\"report\")).read(), metadata=dict(isolated=True))\n"
    ]
   },
   {


### PR DESCRIPTION
Thanks Amy for these tips.  We don't need the smart_open import.  The isolated=True renders the content in an iframe and, once it's there, plotly works in a local environment and we can see all the graphs.