### PR TITLE
[INFRA] INT-578: Run new test suite for UseCases in CI

### DIFF
--- a/.github/workflows/validate_use_cases.yml
+++ b/.github/workflows/validate_use_cases.yml
@@ -1,0 +1,38 @@
+name: Validate Use Cases
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - "**"
+
+jobs:
+  validate-configs:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup and install deps
+      - uses: actions/checkout@v1
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+
+      # Run tests
+      - name: Unit tests
+        run: |
+          pytest -s -vv test_use_cases.py
+        if: ${{ github.base_ref != 'main' }}
+
+      # job notif
+      - uses: 8398a7/action-slack@v2
+        with:
+          status: ${{ job.status }}
+          author_name: Validate Use Cases
+          only_mention_fail: here
+        env:
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()


### PR DESCRIPTION
## Problem
We want to make sure our use case config stays valid. In the original PR, I wrote a python test to do this validation. However, we want to insure it runs on any PR in CI.

## Solution
Add a GitHub Action to run the test on PR opens and updates.