### PR TITLE
[Feat] INT-608 Add filse size to sampledataset metadatas referenced in use cases

### DIFF
--- a/test_use_cases.py
+++ b/test_use_cases.py
@@ -31,6 +31,7 @@ card_schema = {
                 "records": {"type": "number"},
                 "fields": {"type": "number"},
                 "trainingTime": {"type": "string"},
+                "bytes": {"type": "number"},
             },
             "required": [
                 "fileName",
@@ -38,6 +39,7 @@ card_schema = {
                 "records",
                 "fields",
                 "trainingTime",
+                "bytes",
             ],
         },
         "docsUrl": {"type": "string"},

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -11,7 +11,8 @@
         "description": "Use this sample electronic health records (EHR) dataset to synthesize an entirely new set of statistically equivalent records.",
         "records": 9999,
         "fields": 18,
-        "trainingTime": "6 minutes"
+        "trainingTime": "6 minutes",
+        "bytes": 830021
       },
       "gtmId": "use-case-synthetic"
     },
@@ -43,7 +44,8 @@
         "description": "This public dataset of bicycle sales provides a good example of commonly found sensitive data in sales records. Use it to quickly label names, emails, social security numbers, etc.",
         "records": 99,
         "fields": 23,
-        "trainingTime": "< 1 min"
+        "trainingTime": "< 1 min",
+        "bytes": 15996
       },
       "gtmId": "use-case-identify-pii"
     },
@@ -58,7 +60,8 @@
         "description": "Unstructured text datasets are useful for training chatbots or other models that need large amounts of data. The emails in this public dataset need to be de-identified before they can be used to train ML models.",
         "records": 100,
         "fields": 2,
-        "trainingTime": "< 1 min"
+        "trainingTime": "< 1 min",
+        "bytes": 65300
       },
       "gtmId": "use-case-redact-pii"
     },


### PR DESCRIPTION
## Problem
We frequently want to display the file size of sample datasets to folks viewing them in Console. When we initially added them to the Use Cases JSON, we forgot to add this detail!

## Solution
Add this data to the sample dataset metadata within the use cases. This allows us to display the file size without needing to load the file in Console, and keeps all the important info about the file in one place. Since we already need to update this info any time a file changes (and they don't change frequently), this feels like a decent, simple solution for now.