### PR TITLE
[FIX] update use case model types, fix config file path for one

### DIFF
--- a/test_use_cases.py
+++ b/test_use_cases.py
@@ -16,10 +16,6 @@ card_schema = {
                 "synthetics",
                 "transform",
                 "classify",
-                "ctgan",
-                "amplify",
-                "gpt_x",
-                "evaluate",
             ],
         },
         "defaultConfig": {"type": "string"},
@@ -68,6 +64,7 @@ def test_use_cases():
         gtm_ids.append(card["gtmId"])
         titles.append(card["title"])
         validate_images_exist(card["imageName"])
+        validate_config_files_exist(card["defaultConfig"])
 
     validate_unique(gtm_ids)
     validate_unique(titles)
@@ -103,3 +100,6 @@ def validate_images_exist(image_name):
     assert (Path(__file__).parent / dir_path / image_name).is_file()
     assert (Path(__file__).parent / dir_path / two_x).is_file()
     assert (Path(__file__).parent / dir_path / three_x).is_file()
+
+def validate_config_files_exist(config_path):
+    assert (Path(__file__).parent / config_path).is_file()

--- a/test_use_cases.py
+++ b/test_use_cases.py
@@ -10,12 +10,38 @@ card_schema = {
         "title": {"type": "string"},
         "description": {"type": "string"},
         "imageName": {"type": "string"},
+        # "model" is deprecated, will be removed soon. replaced by "modelType"
         "model": {
             "type": "string",
             "enum": [
                 "synthetics",
                 "transform",
                 "classify",
+                "ctgan",
+                "amplify",
+                "gpt_x",
+                "evaluate",
+            ],
+        },
+        "modelType": {
+            "type": "string",
+            "enum": [
+                "synthetics",
+                "transform",
+                "classify",
+                "ctgan",
+                "amplify",
+                "gpt_x",
+                "evaluate",
+            ],
+        },
+        "modelCategory": {
+            "type": "string",
+            "enum": [
+                "synthetics",
+                "transform",
+                "classify",
+                "evaluate",
             ],
         },
         "defaultConfig": {"type": "string"},

--- a/test_use_cases.py
+++ b/test_use_cases.py
@@ -101,5 +101,6 @@ def validate_images_exist(image_name):
     assert (Path(__file__).parent / dir_path / two_x).is_file()
     assert (Path(__file__).parent / dir_path / three_x).is_file()
 
+
 def validate_config_files_exist(config_path):
     assert (Path(__file__).parent / config_path).is_file()

--- a/test_use_cases.py
+++ b/test_use_cases.py
@@ -18,9 +18,11 @@ card_schema = {
                 "transform",
                 "classify",
                 "ctgan",
+                "actgan",
                 "amplify",
                 "gpt_x",
                 "evaluate",
+                "lstm",
             ],
         },
         "modelType": {
@@ -30,9 +32,11 @@ card_schema = {
                 "transform",
                 "classify",
                 "ctgan",
+                "actgan",
                 "amplify",
                 "gpt_x",
                 "evaluate",
+                "lstm",
             ],
         },
         "modelCategory": {

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -5,6 +5,8 @@
       "description": "Convert your real-world data into private, shareable, synthetic data.",
       "imageName": "syntheticdata.png",
       "model": "synthetics",
+      "modelType": "synthetics",
+      "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/default.yml",
       "sampleDataset": {
         "fileName": "sample-synthetic-healthcare.csv",
@@ -20,7 +22,9 @@
       "title": "Amplify data",
       "description": "Create a high volume of synthetic records from real-world data or data that has already been synthesized.",
       "imageName": "amplify.png",
-      "model": "synthetics",
+      "model": "amplify",
+      "modelType": "amplify",
+      "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/amplify.yml",
       "gtmId": "use-case-amplify",
       "tag": "New"
@@ -29,7 +33,9 @@
       "title": "Generate natural language data",
       "description": "Use GPT to create high quality free form synthetic text from single column datasets.",
       "imageName": "natural-lang-gpt.png",
-      "model": "synthetics",
+      "model": "amplify",
+      "modelType": "amplify",
+      "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/natural-language.yml",
       "gtmId": "use-case-natural-lang-gpt"
     },
@@ -38,6 +44,8 @@
       "description": "Use NLP to find and label sensitive information. More than 40 entities supported.",
       "imageName": "identifypii.png",
       "model": "classify",
+      "modelType": "classify",
+      "modelCategory": "classify",
       "defaultConfig": "config_templates/gretel/classify/default.yml",
       "sampleDataset": {
         "fileName": "sample-classify-bike-sales.csv",
@@ -54,6 +62,8 @@
       "description": "Perform privacy preserving transformations on your sensitive data.",
       "imageName": "redactpii.png",
       "model": "transform",
+      "modelType": "transform",
+      "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/default.yml",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
@@ -70,6 +80,8 @@
       "description": "Achieve the highest level of safety by adding differential privacy.",
       "imageName": "synthetic-dp.png",
       "model": "synthetics",
+      "modelType": "synthetics",
+      "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/differential-privacy.yml",
       "gtmId": "use-case-synthetic-dp"
     }

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -20,7 +20,7 @@
       "title": "Amplify data",
       "description": "Create a high volume of synthetic records from real-world data or data that has already been synthesized.",
       "imageName": "amplify.png",
-      "model": "amplify",
+      "model": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/amplify.yml",
       "gtmId": "use-case-amplify",
       "tag": "New"
@@ -29,8 +29,8 @@
       "title": "Generate natural language data",
       "description": "Use GPT to create high quality free form synthetic text from single column datasets.",
       "imageName": "natural-lang-gpt.png",
-      "model": "amplify",
-      "defaultConfig": "config_templates/gretel/synthetics/natural-language-gpt.yml",
+      "model": "synthetics",
+      "defaultConfig": "config_templates/gretel/synthetics/natural-language.yml",
       "gtmId": "use-case-natural-lang-gpt"
     },
     {


### PR DESCRIPTION
## Problem
When we initially built out the use cases JSON, we set the modeltype for amplify tasks as "amplify" but they're technically 'synthetics'. Console needs them to be marked as synthetics due to how the config templates are currently organized, too. Because it wasn't organized in this way, grabbing the correct config template for a use case wasn't working well. I also noticed that one use case specified a config file that didn't actually exist. oops!

## Solution
Update amplify use cases to specify a model type of synthetics. Fix the file name. Add a validation check that the config files for use cases actually exist.