### PR TITLE
Add Discord link under support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The `utils` directory contains helper scripts and tools for environment configur
 # Support
 
 Please open a support ticket at `support [at] gretel.ai` or create a GitHub issue in this repository.
+
+You can also join the Synthetic Data Community Discord to ask questions or suggest new Blueprints.
+
+[![Discord](https://img.shields.io/discord/1007817822614847500?label=Discord&logo=Discord)](https://gretel.ai/discord)


### PR DESCRIPTION
This PR adds a link to our Discord server as an additional support or community option.