### PR TITLE
Remove `Date` time_column from time series config template.

### DIFF
--- a/config_templates/gretel/synthetics/time-series.yml
+++ b/config_templates/gretel/synthetics/time-series.yml
@@ -1,14 +1,17 @@
 # Default configuration for specialized time series model.
 
+# For a complete list of configuration options and detailed documentation, see
+# https://docs.gretel.ai/gretel.ai/synthetics/models/gretel-dgan
+
 schema_version: "1.0"
 name: "time-series-dgan"
 models:
   - timeseries_dgan:
         data_source: "_"
 
-        # Replace with the column name containing the date or time
-        # values in your dataset.
-        time_column: "Date"
+        # If time series data contains a time column, uncomment
+        # and update with the column name.
+        # time_column: "Date"
         
         # Replace with "wide" if time series data is in a wide 
         # format.


### PR DESCRIPTION
## Problem
The time series config template previously assumed there was a `Date` column in the input data, with a comment to replace with your time column name. However, this led to frequent errors when the config template was not customized. 

## Solution
Comment out the `time_column` parameter, with instructions to uncomment and replace the name with the time column used in your own data.

Also added a link to the full documentation for the DGAN model, which contains more detailed info about all the configuration options.

