### PR TITLE
Switch CTGAN to ACTGAN.

### DIFF
--- a/config_templates/gretel/synthetics/high-dimensionality.yml
+++ b/config_templates/gretel/synthetics/high-dimensionality.yml
@@ -6,7 +6,7 @@
 schema_version: "1.0"
 name: "high-dimensionality"
 models:
-  - ctgan:
+  - actgan:
         data_source: __tmp__
         params:
             epochs: 600

--- a/config_templates/gretel/synthetics/low-record-count.yml
+++ b/config_templates/gretel/synthetics/low-record-count.yml
@@ -5,7 +5,7 @@
 schema_version: "1.0"
 name: "low-record-count"
 models:
-  - ctgan:
+  - actgan:
         data_source: __tmp__
         params:
             epochs: 600


### PR DESCRIPTION
This change updates existing config templates to use ACTGAN model, instead of CTGAN.

Note (1): this change is backward compatible, as all of the parameters that CTGAN supported are supported by ACTGAN as well.

Note (2): any previously trained CTGAN models will be still usable, i.e. it will be possible to generate new records using old CTGAN models.