### PR TITLE
Add generate param to GPTX config template.

### DIFF
--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -13,4 +13,6 @@ models:
       weight_decay: 0.01
       warmup_steps: 100
       lr_scheduler: "linear"
-      learning_rate: 0.0002     
+      learning_rate: 0.0002
+      generate:
+        num_records: 10


### PR DESCRIPTION
With GPT data preview now available, this change in the config adds explicit `generate` section to control how many records are generated in the preview.