### PR TITLE
[FIX] INT-788 Fix icon for High-dimensional use case card

### DIFF
--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -96,7 +96,7 @@
       "title": "Synthesize highly dimensional data",
       "description": "Train a synthetic ACTGAN model designed to easily handle datasets with 50k+ records and 100+ columns.",
       "cardType": "Console",
-      "imageName": "synthetics.png",
+      "imageName": "high-dimensional.png",
       "modelType": "synthetics",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",


### PR DESCRIPTION
## Problem
We are using the general synthetic use case card icon for the high-dimensional synthetic card, but it has its own icon.

## Solution
The icon image is already in the images directory, so just reference it instead of the synthetic one.

## Testing
The use_case test suite should still pass in CI :)