### PR TITLE
Relational Transforms joins and config

### DIFF
--- a/docs/notebooks/transform_relational_database.ipynb
+++ b/docs/notebooks/transform_relational_database.ipynb
@@ -270,7 +270,7 @@
         "\n",
         "configs = {}\n",
         "for table in relational_data.list_all_tables():\n",
-        "    configs[table] = read_model_config(\"https://gretel-blueprints-pub.s3.amazonaws.com/rdb/transforms_config.yaml\")\n"
+        "    configs[table] = read_model_config(\"https://raw.githubusercontent.com/gretelai/gdpr-helpers/main/src/config/transforms_config.yaml\")\n"
       ]
     },
     {

--- a/docs/notebooks/transform_relational_database.ipynb
+++ b/docs/notebooks/transform_relational_database.ipynb
@@ -2,36 +2,36 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "TK3tkdsbG2xs"
+      },
       "source": [
         "<a target=\"_blank\" href=\"https://colab.research.google.com/github/gretelai/gretel-blueprints/blob/main/docs/notebooks/transform_relational_database.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
-      ],
-      "metadata": {
-        "id": "TK3tkdsbG2xs"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "SYRvd6uJSyHC"
+      },
       "source": [
         "# Transform a Database with Gretel Relational\n",
         "\n",
         "This notebook uses [Gretel Relational Transform](https://docs.gretel.ai/reference/relational) to redact Personal Identifiable Information (PII) in a sample telecommunications database. Try running the example below and compare the transformed vs real world data.\n",
         "\n",
         "<img src=\"https://gretel-blueprints-pub.s3.us-west-2.amazonaws.com/rdb/telecom_db.png\"  width=\"70%\" height=\"70%\">"
-      ],
-      "metadata": {
-        "id": "SYRvd6uJSyHC"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Getting Started"
-      ],
       "metadata": {
         "id": "mS4Yi2LiSvaZ"
-      }
+      },
+      "source": [
+        "## Getting Started"
+      ]
     },
     {
       "cell_type": "code",
@@ -59,37 +59,42 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Download sample database\n",
-        "!wget https://gretel-blueprints-pub.s3.amazonaws.com/rdb/telecom.db"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "y7uMBkKrHtyt"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# Download sample database\n",
+        "!wget https://gretel-blueprints-pub.s3.amazonaws.com/rdb/telecom.db"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Define Source Data"
-      ],
       "metadata": {
         "id": "6PM0dEEEsi4H"
-      }
+      },
+      "source": [
+        "## Define Source Data"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "9Sji4PdVFuVF"
+      },
       "source": [
         "### Input data via database connector\n",
         "For information on connecting to your own database using one of our 30+ connectors, [check out our docs](https://docs.gretel.ai/reference/relational/database-connectors)."
-      ],
-      "metadata": {
-        "id": "9Sji4PdVFuVF"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Psa3cAaCshFq"
+      },
+      "outputs": [],
       "source": [
         "# Input data from database\n",
         "from gretel_trainer.relational import sqlite_conn\n",
@@ -97,24 +102,25 @@
         "db_path = \"telecom.db\"\n",
         "conn = sqlite_conn(db_path)\n",
         "relational_data = conn.extract()"
-      ],
-      "metadata": {
-        "id": "Psa3cAaCshFq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Alternatively, manually define data from CSVs"
-      ],
       "metadata": {
         "id": "Ndj779pNgbr0"
-      }
+      },
+      "source": [
+        "### Alternatively, manually define data from CSVs"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "Dfi8kLbrgfTH"
+      },
+      "outputs": [],
       "source": [
         "#@title\n",
         "# Alternatively, manually define relational data\n",
@@ -150,16 +156,16 @@
         "\n",
         "# for fk, ref in foreign_keys:\n",
         "#     relational_data.add_foreign_key(foreign_key=fk, referencing=ref)"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "Dfi8kLbrgfTH"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "NwHT39fzF2yK"
+      },
+      "outputs": [],
       "source": [
         "#@title Preview source data\n",
         "#@markdown #### Confirm referential integrity by joining two tables\n",
@@ -168,19 +174,28 @@
         "\n",
         "from IPython.display import display, HTML\n",
         "\n",
-        "def join_tables(parent: str, child: str, relational_data=relational_data):\n",
+        "def join_tables(parent: str, child: str, relational_data: RelationalData, tableset=None):\n",
         "  p_key = relational_data.get_primary_key(parent)\n",
         "  f_key = \"\"\n",
-        "  for fk in relational_data.get_foreign_keys(child):\n",
-        "    if fk.parent_table_name==parent:\n",
-        "      f_key=fk.column_name\n",
-        "    else:\n",
-        "      logging.warning(\"The input parent and child table must be related.\")\n",
-        "  \n",
-        "  parent_df = relational_data.get_table_data(parent)\n",
-        "  child_df = relational_data.get_table_data(child)\n",
         "\n",
-        "  joined_data = child_df.merge(parent_df, how=\"left\", left_on=p_key, right_on=f_key)\n",
+        "  # For simplicity, if a child has multiple foreign keys to a parent, just pick one of them\n",
+        "  child_foreign_keys = {\n",
+        "    fk.parent_table_name: fk.column_name\n",
+        "    for fk in relational_data.get_foreign_keys(child)\n",
+        "  }\n",
+        "  if parent in child_foreign_keys:\n",
+        "    f_key = child_foreign_keys[parent]\n",
+        "  else:\n",
+        "    logging.warning(\"The input parent and child table must be related.\")\n",
+        "  \n",
+        "  if tableset is None:\n",
+        "    parent_df = relational_data.get_table_data(parent)\n",
+        "    child_df = relational_data.get_table_data(child)\n",
+        "  else:\n",
+        "    parent_df = tableset[parent]\n",
+        "    child_df = tableset[child]\n",
+        "\n",
+        "  joined_data = child_df.merge(parent_df, how=\"left\", left_on=f_key, right_on=p_key)\n",
         "\n",
         "  print(f\"Number of records in {child} table:\\t {len(child_df)}\")\n",
         "  print(f\"Number of records in {parent} table:\\t {len(parent_df)}\")\n",
@@ -193,15 +208,9 @@
         "child_table = \"account\" #@param {type:\"string\"}\n",
         "\n",
         "print(\"\\033[1m Source Data: \\033[0m\")\n",
-        "source_data = join_tables(parent_table, child_table)\n",
+        "source_data = join_tables(parent_table, child_table, relational_data)\n",
         "display(source_data)  \n"
-      ],
-      "metadata": {
-        "id": "NwHT39fzF2yK",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -242,12 +251,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Set Transform configuration"
-      ],
       "metadata": {
         "id": "yrArborLR9Ta"
-      }
+      },
+      "source": [
+        "### Set Transform configuration"
+      ]
     },
     {
       "cell_type": "code",
@@ -266,12 +275,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Transform Database"
-      ],
       "metadata": {
         "id": "bx3b5ve9SIDY"
-      }
+      },
+      "source": [
+        "## Transform Database"
+      ]
     },
     {
       "cell_type": "code",
@@ -298,8 +307,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "5ltc4Nx5Ba4S",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "5ltc4Nx5Ba4S"
       },
       "outputs": [],
       "source": [
@@ -317,71 +326,57 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "9P40pDY71cX_"
+      },
+      "outputs": [],
       "source": [
         "#@title Examine joined tables to confirm referential integrity\n",
         "#@markdown As with the original data, every record in the transformed child table matches a distinct record in its transformed parent table. The number of records in the joined data matches the number of records in the child table, confirming referential integrity has been maintained in the transformed database.\n",
         "import logging \n",
         "from IPython.display import display, HTML\n",
         "\n",
-        "def join_trans_tables(parent: str, child: str, multitable=multitable): \n",
-        "  p_key = multitable.relational_data.get_primary_key(parent)\n",
-        "  f_key = \"\"\n",
-        "  for fk in multitable.relational_data.get_foreign_keys(child):\n",
-        "    if fk.parent_table_name==parent:\n",
-        "      f_key=fk.column_name\n",
-        "    else:\n",
-        "      logging.warning(\"The input parent and child table must be related.\")\n",
-        "  \n",
-        "  parent_df = multitable.transform_output_tables[parent]\n",
-        "  child_df = multitable.transform_output_tables[child]\n",
-        "\n",
-        "  joined_data = child_df.merge(parent_df, how=\"left\", left_on=p_key, right_on=f_key)\n",
-        "\n",
-        "  print(f\"Number of records in {child} table:\\t {len(child_df)}\")\n",
-        "  print(f\"Number of records in {parent} table:\\t {len(parent_df)}\")\n",
-        "  print(f\"Number of records in joined data:\\t {len(joined_data)}\")\n",
-        "  return joined_data.head()\n",
-        "\n",
         "\n",
         "parent_table = \"client\" #@param {type:\"string\"}\n",
         "child_table = \"account\" #@param {type:\"string\"}\n",
         "\n",
         "print(\"\\n\\n\\033[1m Transformed Data:\\033[0m\")\n",
-        "display(join_trans_tables(parent_table, child_table)[source_data.columns])"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "9P40pDY71cX_"
-      },
-      "execution_count": null,
-      "outputs": []
+        "display(join_tables(parent_table, child_table, multitable.relational_data, multitable.transform_output_tables)[source_data.columns])"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "aO04kQCFESjh"
+      },
+      "outputs": [],
       "source": [
         "#@title Accessing Output Files\n",
         "#@markdown All of the Relational Transform output files can be found in your local working directory. Additionally, you can download the outputs as a single archive file from the Gretel Console using this URL:\n",
         "console_url = f\"https://console.gretel.ai/{multitable._project.name}/data_sources\"\n",
         "print(console_url)"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "aO04kQCFESjh"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## [Optional] Save Transformed Data to a Database\n"
-      ],
       "metadata": {
         "id": "VWhUpzYoT-W-"
-      }
+      },
+      "source": [
+        "## [Optional] Save Transformed Data to a Database\n"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2TMQSrRdUMLC"
+      },
+      "outputs": [],
       "source": [
         "output_db_path = \"transformed_telecom.db\"\n",
         "output_conn = sqlite_conn(output_db_path)\n",
@@ -389,18 +384,14 @@
         "    multitable.transform_output_tables,\n",
         "    prefix=\"trans_\"\n",
         "    )"
-      ],
-      "metadata": {
-        "id": "2TMQSrRdUMLC"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {
     "colab": {
       "provenance": []
     },
+    "gpuClass": "premium",
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",
@@ -422,8 +413,7 @@
       "interpreter": {
         "hash": "2bdb4985d2c4ccdd9da3d80dbbcd61329f4e8765a7715ea050d7419e0fe0515c"
       }
-    },
-    "gpuClass": "premium"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
### What's here
- Fixes the primary/foreign key, left-on/right-on values in the `join_tables` function
- Refactors `join_tables` to support source or transformed output, and removes the nearly-duplicative version previously used for output tables
- Removes unnecessary warnings
- Use the GDPR transforms config by default
- VSCode notebook formatting noise 😒 