### PR TITLE
Add modelCategory in modelTypesList

### DIFF
--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -2,6 +2,7 @@
   "modelTypes": [
     {
       "modelType": "synthetics",
+      "modelCategory" : "synthetics",
       "defaultConfig":  "config_templates/gretel/synthetics/tabular-lstm-evaluate.yml",
       "sampleDataset": {
         "fileName": "bank_marketing_small.csv",
@@ -53,6 +54,7 @@
     },
     {
       "modelType": "transform",
+      "modelCategory" : "transform",
       "defaultConfig": "config_templates/gretel/transform/default.yml",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
@@ -65,6 +67,7 @@
     },
     {
       "modelType": "classify",
+      "modelCategory" : "classify",
       "defaultConfig": "config_templates/gretel/classify/default.yml",
       "sampleDataset": {
         "fileName": "sample-classify-bike-sales.csv",

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -14,6 +14,7 @@
     },
     {
       "modelType": "gpt_x",
+      "modelCategory" : "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/natural-language.yml",
       "sampleDataset": {
         "fileName": "taylor-swift-lyrics.csv",
@@ -26,6 +27,7 @@
     },
     {
       "modelType": "actgan",
+      "modelCategory" : "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
       "sampleDataset": {
         "fileName": "sample-synthetic-healthcare.csv",
@@ -38,6 +40,7 @@
     },
     {
       "modelType": "amplify",
+      "modelCategory" : "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/amplify.yml",
       "sampleDataset": {
         "fileName": "safe-driver-prediction.csv",
@@ -46,18 +49,6 @@
         "fields": 59,
         "trainingTime": "< 5 mins",
         "bytes": 100000000
-      }
-    },
-    {
-      "modelType": "evaluate",
-      "defaultConfig": "config_templates/gretel/evaluate/default.yml",
-      "sampleDataset": {
-        "fileName": "bank_marketing_small.csv",
-        "description": "Create synthetic data based on the publicly available dataset predicting opting in or out of bank marketing.",
-        "records": 4521,
-        "fields": 17,
-        "trainingTime": "< 10 mins",
-        "bytes": 371020
       }
     },
     {


### PR DESCRIPTION
ModelCategory needs to be included in the modelTypesList in order to load the correct configurations.

Side note: We don't currently have the ability to load a synthesized dataset from another model to pass into evaluate, so evaluate will be excluded for now until that's possible.