### PR TITLE
substitute steps with epochs

### DIFF
--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -10,7 +10,7 @@ models:
       data_source: "__temp__"
       pretrained_model: "gretelai/mpt-7b"
       batch_size: 4
-      steps: 900
+      steps: 750
       weight_decay: 0.01
       warmup_steps: 100
       lr_scheduler: "linear"

--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -10,7 +10,7 @@ models:
       data_source: "__temp__"
       pretrained_model: "gretelai/mpt-7b"
       batch_size: 4
-      epochs: 3
+      steps: 900
       weight_decay: 0.01
       warmup_steps: 100
       lr_scheduler: "linear"


### PR DESCRIPTION
Replace epochs with steps for independent training time from the number of training examples while maintaining a proper performance (semantic similarity score) within 1 hour training time limit. More explained in [this](https://gretel.atlassian.net/wiki/spaces/AS/pages/2032205825/Setting+a+Fixed+Value+for+the+Steps+Parameter+in+the+GPT-x+Model) document.