### PR TITLE
[FEAT] INT-1527 Add markdown file and button placeholder for synth console card

### DIFF
--- a/use_cases/details/synthetic.md
+++ b/use_cases/details/synthetic.md
@@ -1,0 +1,1 @@
+Use our standard synthetic model to create highly accurate synthetic training data for ML models.

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -6,6 +6,7 @@
       "description": "Create highly accurate synthetic training data for ML models.",
       "cardType": "Console",
       "imageName": "synthetics.png",
+      "detailsFileName": "synthetic.md",
       "modelType": "synthetics",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
@@ -16,6 +17,10 @@
         "fields": 18,
         "trainingTime": "6 mins",
         "bytes": 830021
+      },
+      "button1": {
+        "label": "Try it out in Google Colab",
+        "link": "https://colab.research.google.com/github/gretelai/gretel-blueprints/blob/main/docs/notebooks/synthesize_relational_database.ipynb"
       }
     },
     {


### PR DESCRIPTION
## Problem
For some models, we have "Console" cards and "Notebook" cards. We want to be able to give users a little more context on some "Console" cards, along with an optional notebook to review for setting parameters and the like.

## Solution
Add placeholders for the Synthetic card, so product can see how to update Console cards to add this info in a way that the Console app will digest it. Note that the text and button link are placeholders -- we'll use them just in development until product updates them to the content we actually want.