### PR TITLE
[REFACTOR] Add model type descriptions and labels to gretel-blueprint definitions

### DIFF
--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -5,6 +5,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
       "description": "Our speediest and most efficient GAN model for generating highly dimensional numeric and categorical tabular data.",
+      "label": "Synthetic ACTGAN",
       "sampleDataset": {
         "fileName": "monthly-customer-payments.csv",
         "description": "This dataset of monthly customer charges contains sensitive information and more than 20 columns.",
@@ -19,6 +20,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/natural-language.yml",
       "description": "GPT3-like pre-trained transformer model for generating natural language text from an input file.",
+      "label": "GPT",
       "sampleDataset": {
         "fileName": "sample-banking-questions-intents.csv",
         "description": "Create realistic banking-related questions and intent labels using this sample dataset.",
@@ -33,6 +35,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-differential-privacy.yml",
       "description": "Fast, graph-based synthetic data model with strong differential privacy guarantees",
+      "label": "Tabular DP",
       "sampleDataset": {
         "fileName": "bank_marketing_small.csv",
         "description": "This dataset contains direct marketing campaign details (phone calls) from a Portuguese financial institution. It has sensitive information such as demographics and financials, which can benefit from privacy preserving techniques before sharing.  ",
@@ -47,6 +50,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/time-series.yml",
       "description": "DoppelGANger model optimized to generate highly realistic time-series data.",
+      "label": "DGAN",
       "sampleDataset": {
         "fileName": "daily-website-visitors.csv",
         "description": "Safely synthesize a dataset of daily website visitors while maintaining correlations and data patterns.",
@@ -61,6 +65,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-lstm.yml",
       "description": "Language model capable of generating multi-modal tabular data including mixed categorical, numeric, time-series, and text fields.",
+      "label": "Synthetic LSTM",
       "sampleDataset": {
         "fileName": "sample-synthetic-healthcare.csv",
         "description": "Use this sample electronic health records (EHR) dataset to synthesize an entirely new set of statistically equivalent records.",
@@ -75,6 +80,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/amplify.yml",
       "description": "Statistical model that supports high volumes of tabular data generation for pre-production use cases.",
+      "label": "Amplify",
       "sampleDataset": {
         "fileName": "safe-driver-prediction.csv",
         "description": "Use this dataset to predict if a driver will file an insurance claim in the following year. Specify an output size in the config. By default, the model will create as many records as the input dataset.",
@@ -89,6 +95,7 @@
       "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
       "description": "Flexible data pre and post processing toolkit including support for detecting arbitrary PII entities, configurable data generation templates, and faster speed.",
+      "label": "Transform V2",
       "sampleDataset": {
         "fileName": "patients.csv",
         "description": "This patient dataset contains names, addresses and other personally identifiable information, which needs to be redacted before the dataset can be shared or used to train ML models.",
@@ -103,6 +110,7 @@
       "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/default.yml",
       "description": "Detect and transform PII entities in datasets, including named entity recognition within free text fields.",
+      "label": "Transform",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
         "description": "Unstructured text datasets are useful for training chatbots or other models that need large amounts of data. The emails in this public dataset need to be de-identified before they can be used to train ML models.",
@@ -117,6 +125,7 @@
       "modelCategory": "classify",
       "defaultConfig": "config_templates/gretel/classify/default.yml",
       "description": "Identifies sensitive data, including personally identifiable information (PII), credentials, and custom values inside text, logs, and other structured data.",
+      "label": "Classify",
       "sampleDataset": {
         "fileName": "sample-classify-bike-sales.csv",
         "description": "This public dataset of bicycle sales provides a good example of commonly found sensitive data in sales records. Use it to quickly label names, emails, social security numbers, etc.",
@@ -131,6 +140,7 @@
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-lstm-evaluate.yml",
       "description": "Synthesizes data and validates it for downstream models using comprehensive quality and utility reporting.",
+      "label": "Evaluate",
       "sampleDataset": {
         "fileName": "bank_marketing_small.csv",
         "description": "Create synthetic data based on the publicly available dataset predicting opting in or out of bank marketing.",

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -88,7 +88,7 @@
       "modelType": "transform_v2",
       "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
-      "description": "Identifies and transforms private information, using modular building blocks to allow for fast generation and high flexibility.",
+      "description": "Flexible data pre and post processing toolkit including support for detecting arbitrary PII entities, configurable data generation templates, and faster speed.",
       "sampleDataset": {
         "fileName": "patients.csv",
         "description": "This patient dataset contains names, addresses and other personally identifiable information, which needs to be redacted before the dataset can be shared or used to train ML models.",
@@ -102,7 +102,7 @@
       "modelType": "transform",
       "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/default.yml",
-      "description": "Labels and transforms a dataset, with advanced options such as custom regular expression search, date shifting, and fake entity replacements.",
+      "description": "Detect and transform PII entities in datasets, including named entity recognition within free text fields.",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
         "description": "Unstructured text datasets are useful for training chatbots or other models that need large amounts of data. The emails in this public dataset need to be de-identified before they can be used to train ML models.",

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -4,6 +4,7 @@
       "modelType": "actgan",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
+      "description": "Our speediest and most efficient GAN model for generating highly dimensional numeric and categorical tabular data.",
       "sampleDataset": {
         "fileName": "monthly-customer-payments.csv",
         "description": "This dataset of monthly customer charges contains sensitive information and more than 20 columns.",
@@ -17,6 +18,7 @@
       "modelType": "gpt_x",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/natural-language.yml",
+      "description": "GPT3-like pre-trained transformer model for generating natural language text from an input file.",
       "sampleDataset": {
         "fileName": "sample-banking-questions-intents.csv",
         "description": "Create realistic banking-related questions and intent labels using this sample dataset.",
@@ -30,6 +32,7 @@
       "modelType": "tabular_dp",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-differential-privacy.yml",
+      "description": "Fast, graph-based synthetic data model with strong differential privacy guarantees",
       "sampleDataset": {
         "fileName": "bank_marketing_small.csv",
         "description": "This dataset contains direct marketing campaign details (phone calls) from a Portuguese financial institution. It has sensitive information such as demographics and financials, which can benefit from privacy preserving techniques before sharing.  ",
@@ -43,6 +46,7 @@
       "modelType": "timeseries_dgan",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/time-series.yml",
+      "description": "DoppelGANger model optimized to generate highly realistic time-series data.",
       "sampleDataset": {
         "fileName": "daily-website-visitors.csv",
         "description": "Safely synthesize a dataset of daily website visitors while maintaining correlations and data patterns.",
@@ -56,6 +60,7 @@
       "modelType": "synthetics",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-lstm.yml",
+      "description": "Language model capable of generating multi-modal tabular data including mixed categorical, numeric, time-series, and text fields.",
       "sampleDataset": {
         "fileName": "sample-synthetic-healthcare.csv",
         "description": "Use this sample electronic health records (EHR) dataset to synthesize an entirely new set of statistically equivalent records.",
@@ -69,6 +74,7 @@
       "modelType": "amplify",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/amplify.yml",
+      "description": "Statistical model that supports high volumes of tabular data generation for pre-production use cases.",
       "sampleDataset": {
         "fileName": "safe-driver-prediction.csv",
         "description": "Use this dataset to predict if a driver will file an insurance claim in the following year. Specify an output size in the config. By default, the model will create as many records as the input dataset.",
@@ -82,6 +88,7 @@
       "modelType": "transform_v2",
       "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
+      "description": "Identifies and transforms private information, using modular building blocks to allow for fast generation and high flexibility.",
       "sampleDataset": {
         "fileName": "patients.csv",
         "description": "This patient dataset contains names, addresses and other personally identifiable information, which needs to be redacted before the dataset can be shared or used to train ML models.",
@@ -95,6 +102,7 @@
       "modelType": "transform",
       "modelCategory": "transform",
       "defaultConfig": "config_templates/gretel/transform/default.yml",
+      "description": "Labels and transforms a dataset, with advanced options such as custom regular expression search, date shifting, and fake entity replacements.",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
         "description": "Unstructured text datasets are useful for training chatbots or other models that need large amounts of data. The emails in this public dataset need to be de-identified before they can be used to train ML models.",
@@ -104,11 +112,11 @@
         "bytes": 65300
       }
     },
-
     {
       "modelType": "classify",
       "modelCategory": "classify",
       "defaultConfig": "config_templates/gretel/classify/default.yml",
+      "description": "Identifies sensitive data, including personally identifiable information (PII), credentials, and custom values inside text, logs, and other structured data.",
       "sampleDataset": {
         "fileName": "sample-classify-bike-sales.csv",
         "description": "This public dataset of bicycle sales provides a good example of commonly found sensitive data in sales records. Use it to quickly label names, emails, social security numbers, etc.",
@@ -122,6 +130,7 @@
       "modelType": "evaluate",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-lstm-evaluate.yml",
+      "description": "Synthesizes data and validates it for downstream models using comprehensive quality and utility reporting.",
       "sampleDataset": {
         "fileName": "bank_marketing_small.csv",
         "description": "Create synthetic data based on the publicly available dataset predicting opting in or out of bank marketing.",


### PR DESCRIPTION
## Problem
Today, the `description` and `label` data for model types to show in Console is hard-coded in Console itself (along with a few other things). This means that if we want to change a text description or a model type label, it requires a code change and deploy to production. That's not very efficient.

## Solution
Move it to gretel-blueprints! After this change lands, we can update Console to look for the description and label coming in from gretel-blueprints. This change can go all the way to production before Console uses it, having it here won't hurt anything if we are not using it (we'll just need to remember where the source of truth is).