### PR TITLE
Lower top_k in notebook

### DIFF
--- a/docs/notebooks/demo/gretel-demo-tabularllm-complete-tables.ipynb
+++ b/docs/notebooks/demo/gretel-demo-tabularllm-complete-tables.ipynb
@@ -110,7 +110,7 @@
         "        seed_data: pd.DataFrame,\n",
         "        temperature: float = 0.8,\n",
         "        top_p: float = 1,\n",
-        "        top_k: int = 50,\n",
+        "        top_k: int = 40,\n",
         "        keep_remote_data: bool = False,\n",
         "        verbose: bool = False,\n",
         "    ) -> pd.DataFrame:\n",


### PR DESCRIPTION
Not all LLM providers support a topK >40, so cap our examples at no larger than that