### PR TITLE
chore: reorganize new sample connection cards

### DIFF
--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -146,6 +146,26 @@
       }
     },
     {
+      "gtmId": "use-case-transform-database",
+      "title": "Redact PII in a database",
+      "description": "Safeguard sensitive information and uphold compliance standards by automatically removing private information from your database.",
+      "cardType": "Console",
+      "icon": "relational-db.png",
+      "modelType": "transform_v2",
+      "modelCategory": "transform",
+      "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
+      "sampleConnection": {
+        "id": "sample_mysql_telecom",
+        "type": "mysql",
+        "description": "This telecommunications dataset contains names, addresses, social security numbers, and other personally identifiable information, which needs to be redacted before the dataset can be shared or used to train ML models.",
+        "tables": 5,
+        "records": 230988,
+        "fields": 29,
+        "trainingTime": "5 mins",
+        "bytes": 9537000
+      }
+    },
+    {
       "gtmId": "use-case-downstream-accuracy",
       "title": "Synthesize data + evaluate ML performance",
       "description": "Evaluate synthetic data performance on classification and regression models.",
@@ -310,26 +330,6 @@
       "button1": {
         "label": "Launch Gretel Labs",
         "link": "https://image-synthetics-preview.gretel.cloud/"
-      }
-    },
-    {
-      "gtmId": "use-case-transform-database",
-      "title": "Redact PII in a database",
-      "description": "Safeguard sensitive information and uphold compliance standards by automatically removing private information from your database.",
-      "cardType": "Console",
-      "icon": "relational-db.png",
-      "modelType": "transform_v2",
-      "modelCategory": "transform",
-      "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
-      "sampleConnection": {
-        "id": "sample_mysql_telecom",
-        "type": "mysql",
-        "description": "This telecommunications dataset contains names, addresses, social security numbers, and other personally identifiable information, which needs to be redacted before the dataset can be shared or used to train ML models.",
-        "tables": 5,
-        "records": 230988,
-        "fields": 29,
-        "trainingTime": "5 mins",
-        "bytes": 9537000
       }
     }
   ]

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -28,19 +28,23 @@
       }
     },
     {
-      "gtmId": "use-case-relational-db",
-      "title": "Synthesize any normalized SQL database ",
-      "description": "Use Gretel Relational to synthesize or transform data in a relational database without losing foreign key relationships.",
-      "cardType": "Notebook",
+      "gtmId": "use-case-synthetic-database",
+      "title": "Synthesize a database",
+      "description": "Synthesize a database using Gretel Relational.",
+      "cardType": "Console",
       "icon": "relational-db.png",
-      "detailsFileName": "relational-db.md",
-      "button1": {
-        "label": "Synthesize in Google Colab",
-        "link": "https://colab.research.google.com/github/gretelai/gretel-blueprints/blob/main/docs/notebooks/synthesize_relational_database.ipynb"
-      },
-      "button2": {
-        "label": "Transform in Google Colab",
-        "link": "https://colab.research.google.com/github/gretelai/gretel-blueprints/blob/main/docs/notebooks/transform_relational_database.ipynb"
+      "modelType": "synthetics",
+      "modelCategory": "synthetics",
+      "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
+      "sampleConnection": {
+        "id": "sample_mysql_telecom",
+        "type": "mysql",
+        "description": "Use this sample telecommunications database to synthesize an entirely new database of statistically equivalent records, while maintaining referential integrity.",
+        "tables": 5,
+        "records": 230988,
+        "fields": 29,
+        "trainingTime": "20 mins",
+        "bytes": 9537000
       }
     },
     {
@@ -306,26 +310,6 @@
       "button1": {
         "label": "Launch Gretel Labs",
         "link": "https://image-synthetics-preview.gretel.cloud/"
-      }
-    },
-    {
-      "gtmId": "use-case-synthetic-database",
-      "title": "Synthesize a database",
-      "description": "Synthesize a database using Gretel Relational.",
-      "cardType": "Console",
-      "icon": "relational-db.png",
-      "modelType": "synthetics",
-      "modelCategory": "synthetics",
-      "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
-      "sampleConnection": {
-        "id": "sample_mysql_telecom",
-        "type": "mysql",
-        "description": "Use this sample telecommunications database to synthesize an entirely new database of statistically equivalent records, while maintaining referential integrity.",
-        "tables": 5,
-        "records": 230988,
-        "fields": 29,
-        "trainingTime": "20 mins",
-        "bytes": 9537000
       }
     },
     {


### PR DESCRIPTION
We want the new sample relational connection cards to:
1. Replace the Notebook version
2. Move the transform option up to the 9 spot