### PR TITLE
[bug] INT-1765 filter deprecated configs

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,9 +14,9 @@ async function* walk(dir, ext) {
 
 // Then, use it with a simple async for loop
 async function main() {
-  const templates = [];
+  const configs = [];
   for await (const p of walk("config_templates", /\.ya?ml$/)) {
-    templates.push(p);
+    configs.push(p);
   }
   const samples = [];
   for await (const p of walk("sample_data")) {
@@ -26,6 +26,13 @@ async function main() {
   for await (const p of walk("sample_data_previews")) {
     sample_data_previews.push(p);
   }
+  /* 
+  Files whose first comment is `# deprecated: This configuration will be deprecated soon. <additional message>` are deprecated and filtered from the manifest
+  */
+  const templates = configs.filter((template) => {
+    const str = fs.readFileSync(template, "utf8");
+    return !str.startsWith("# deprecated");
+  });
 
   console.log(JSON.stringify({ templates, samples, sample_data_previews }));
 }


### PR DESCRIPTION
Resolves: [INT-1765](https://gretel.atlassian.net/browse/INT-1765)

# Problem
We used to have logic that looked for a deprecated comment at the top of a config file and hid it from users. The logic has been removed, and we can now see all the deleted config files.

# Solution
Add logic that was previously in the Console to filter templates that are marked `# deprecated.` 

# Additional Notes
This change is implemented on the Blueprints side due to changes in how we fetch and store configs. In Console, we use the `manifest` to provide the list of available configs; we then categorize them by model type and fetch their contents on demand based on user selection. Before, we'd fetch them all at once and then decide which to display by model type.

## Open Questions
~~Are there other consumers than Console that rely on the manifest? Will these changes adversely affect those consumers?~~. None other than Console.

# Testing 
1. Run `yarn build` to generate a new manfest.json file.
2. The array of `templates` should exclude files marked deprecated.

## List of deprecated configs:

https://github.com/gretelai/gretel-blueprints/blob/896456efb4bcfd4ab7a35b65ff6546319be84f9f/config_templates/gretel/synthetics/default.yml#L1
https://github.com/gretelai/gretel-blueprints/blob/896456efb4bcfd4ab7a35b65ff6546319be84f9f/config_templates/gretel/synthetics/high-dimensionality.yml#L1
https://github.com/gretelai/gretel-blueprints/blob/896456efb4bcfd4ab7a35b65ff6546319be84f9f/config_templates/gretel/synthetics/high-accuracy.yml#L1
https://github.com/gretelai/gretel-blueprints/blob/896456efb4bcfd4ab7a35b65ff6546319be84f9f/config_templates/gretel/synthetics/low-record-count.yml#L1
https://github.com/gretelai/gretel-blueprints/blob/896456efb4bcfd4ab7a35b65ff6546319be84f9f/config_templates/gretel/synthetics/complex-or-free-text.yml#L1

## Templates _before_ filtering: 
```
[
 'config_templates/gretel/classify/classify-all-entities.yml',
 'config_templates/gretel/classify/default.yml',
 'config_templates/gretel/classify/classify-pii-nlp-off.yml',
 'config_templates/gretel/classify/classify-pii-regex.yml',
 'config_templates/gretel/classify/classify-pii-nlp-on.yml',
 'config_templates/gretel/synthetics/low-record-count.yml',
 'config_templates/gretel/synthetics/default.yml',
 'config_templates/gretel/synthetics/tabular-actgan.yml',
 'config_templates/gretel/synthetics/high-dimensionality.yml',
 'config_templates/gretel/synthetics/time-series.yml',
 'config_templates/gretel/synthetics/tabular-differential-privacy.yml',
 'config_templates/gretel/synthetics/natural-language.yml',
 'config_templates/gretel/synthetics/amplify.yml',
 'config_templates/gretel/synthetics/tabular-lstm-evaluate.yml',
 'config_templates/gretel/synthetics/tabular-lstm.yml',
 'config_templates/gretel/synthetics/complex-or-free-text.yml',
 'config_templates/gretel/synthetics/high-accuracy.yml',
 'config_templates/gretel/evaluate/default.yml',
 'config_templates/gretel/transform/default.yml',
 'config_templates/gretel/transform/redact-pii-regex.yml',
 'config_templates/gretel/transform/redact-pii-nlp-off.yml',
 'config_templates/gretel/transform/transform_v2.yml'
]
```

## Templates _after_ filtering: 
```
[
 'config_templates/gretel/classify/classify-all-entities.yml',
 'config_templates/gretel/classify/default.yml',
 'config_templates/gretel/classify/classify-pii-nlp-off.yml',
 'config_templates/gretel/classify/classify-pii-regex.yml',
 'config_templates/gretel/classify/classify-pii-nlp-on.yml',
 'config_templates/gretel/synthetics/tabular-actgan.yml',
 'config_templates/gretel/synthetics/time-series.yml',
 'config_templates/gretel/synthetics/tabular-differential-privacy.yml',
 'config_templates/gretel/synthetics/natural-language.yml',
 'config_templates/gretel/synthetics/amplify.yml',
 'config_templates/gretel/synthetics/tabular-lstm-evaluate.yml',
 'config_templates/gretel/synthetics/tabular-lstm.yml',
 'config_templates/gretel/evaluate/default.yml',
 'config_templates/gretel/transform/default.yml',
 'config_templates/gretel/transform/redact-pii-regex.yml',
 'config_templates/gretel/transform/redact-pii-nlp-off.yml',
 'config_templates/gretel/transform/transform_v2.yml'
]
```

 