### PR TITLE
Edits to Navigator playground prompts + new prompts 

### DIFF
--- a/prompts/all.json
+++ b/prompts/all.json
@@ -125,12 +125,26 @@
       ]
     }, 
     {
-      "id": "healthcare-dataset",
+      "id": "medical-diagnosis-prescription-dataset",
       "label": "Create a medical patient dataset", 
       "value": [
         "Generate 15 rows of medical patient data.", 
         "Include these columns: patient_id in the format ##########, patient_name, street_address, city column with US city, state column with corresponding US state, zip_code column with corresponding US zip code, DOB, phone_number in the format ###-##-####, email, diagnosis and correlating prescription."
       ] 
+    }, 
+    {
+      "id": "customer-bank-transaction-dataset",
+      "label": "Create a customer bank transaction dataset", 
+      "value": [
+        "Generate 50 rows of customer bank transaction data. Include the following columns:",
+        "- customer name",
+        "- customer_id",
+        "- transaction_date",
+        "- transaction_amount",   
+        "- transaction_type",     
+        "- transaction_category",
+        "- account_balance"
+      ]
     }
   ]
 }

--- a/prompts/all.json
+++ b/prompts/all.json
@@ -58,7 +58,7 @@
       "id": "foo-users-fr",
       "label": "Create a mock dataset for users from Foo.io who live in France",
       "value": [
-        "Generate a mock dataset for users from the Foo company based in France.",
+        "Generate 25 rows of a mock dataset for users from the Foo company based in France.",
         "Each user should have the following columns:",
         "* first_name: traditional French first names.",
         "* last_name: traditional French surnames. ",
@@ -71,18 +71,18 @@
     {
       "id": "customer-support-banking",
       "label": "Generate realistic customer support questions for an online banking system",
-      "value": "Create a mock dataset: Columns: id, customer_support_question. Generate realistic customer support questions for an online banking system."
+      "value": "Create a mock dataset: Columns: id, customer_support_question. Generate realistic customer support questions for an online banking system. Generate 30 rows of data."
     },
     {
       "id": "product-reviews",
       "label": "Generate positive and negative reviews for a given list of products",
-      "value": "Generate positive and negative reviews for the following products: red travel mug, leather mary jane heels, unicorn LED night light. Columns include the product name, number of stars (1-5), review and customer id"
+      "value": "Generate positive and negative reviews for common household products purchased online. Create 25 rows of data. Columns are: the product name, number of stars (1-5), review and customer id"
     },
     {
       "id": "texas-professionals",
       "label": "Generate a mock dataset for professionals based in Austin, Texas",
       "value": [
-        "Generate a mock dataset for professionals based in Austin, Texas.",
+        "Generate 50 rows of a mock dataset for professionals based in Austin, Texas.",
         "Each entry should have the following columns:",
         "first_name: diverse first names from various cultural backgrounds.",
         "last_name: diverse last names representing a range of ethnicities.",
@@ -96,7 +96,7 @@
       "id": "consumer-packaged-goods",
       "label": "Create a consumer packaged goods dataset",
       "value": [
-        "Create a product dataset with the following columns:",
+        "Create 50 rows of a product dataset with the following columns:",
         "- ISBN: a realistic unique identifier",
         "- Title: the title of a product that is listed online, like: 'Red Travel Mug'",
         "- Description",
@@ -108,6 +108,29 @@
         "- City: city to be shipped",
         "- Country: country of city"
       ]
+    }, 
+    {
+      "id": "input-output-pairs",
+      "label": "Create question and answer data based on a source text",
+      "value": [
+        "From the source text below, create a dataset of 50 rows with the following columns:",
+        " - question: Unique questions about the source text. The question should have a short answer contained within the source text",
+        " - context: Copy the exact sentence(s) from the source text and surrounding details from where the answer can be derived",
+        " - truth: Respond to the question with a clear, textbook quality answer that provides relevant details to fully address the question",
+        " Source text:", 
+        "The Roman Empire was the post-Republican state of ancient Rome and is generally understood to mean the period and territory ruled by the Romans following Octavian's assumption of sole rule under the Principate in 27 BC. It included territory in Europe, North Africa, and Western Asia, and was ruled by emperors. The fall of the Western Roman Empire in 476 conventionally marks the end of classical antiquity and the beginning of the Middle Ages.",
+        "Rome had expanded its rule to most of the Mediterranean and beyond, but became severely destabilized in civil wars and political conflicts which culminated in the victory of Octavian over Mark Antony and Cleopatra at the Battle of Actium in 31 BC and the subsequent conquest of the Ptolemaic Kingdom in Egypt. In 27 BC the Roman Senate granted Octavian overarching power (imperium) and the new title of Augustus, marking his accession as the first Roman emperor of a monarchy with Rome as its sole capital. The vast Roman territories were organized in senatorial and imperial provinces.",
+        "The first two centuries of the Empire saw a period of unprecedented stability and prosperity known as the Pax Romana ('Roman Peace'). Rome reached its greatest territorial expanse under Trajan (AD 98–117); a period of increasing trouble and decline began under Commodus (180–192). In the 3rd century, the Empire underwent a crisis that threatened its existence, as the Gallic and Palmyrene Empires broke away from the Roman state, and a series of short-lived emperors led the Empire. It was reunified under Aurelian (r. 270–275). Diocletian set up two different imperial courts in the Greek East and Latin West in 286; Christians rose to power in the 4th century following the Edict of Milan. The imperial seat moved from Rome to Byzantium in 330, renamed Constantinople after Constantine the Great. The Migration Period, involving large invasions by Germanic peoples and by the Huns of Attila, led to the decline of the Western Roman Empire. With the fall of Ravenna to the Germanic Herulians and the deposition of Romulus Augustus in 476 by Odoacer, the Western Roman Empire finally collapsed. The Eastern Roman Empire survived for another millennium with Constantinople as its sole capital, until the city's fall in 1453.", 
+        "Due to the Empire's extent and endurance, its institutions and culture had a lasting influence on the development of language, religion, art, architecture, literature, philosophy, law, and forms of government in its territories. Latin evolved into the Romance languages, while Medieval Greek became the language of the East. The Empire's adoption of Christianity led to the formation of medieval Christendom. Roman and Greek art had a profound impact on the Italian Renaissance. Rome's architectural tradition served as the basis for Romanesque, Renaissance and Neoclassical architecture, and influenced Islamic architecture. The rediscovery of classical science and technology (which formed the basis for Islamic science) in medieval Europe led to the Scientific Renaissance and Scientific Revolution. Many modern legal systems, such as the Napoleonic Code, descend from Roman law, while Rome's republican institutions have influenced the Italian city-state republics of the medieval period, the early United States, and modern democratic republics."
+      ]
+    }, 
+    {
+      "id": "healthcare-dataset",
+      "label": "Create a medical patient dataset", 
+      "value": [
+        "Generate 15 rows of medical patient data.", 
+        "Include these columns: patient_id in the format ##########, patient_name, street_address, city column with US city, state column with corresponding US state, zip_code column with corresponding US zip code, DOB, phone_number in the format ###-##-####, email, diagnosis and correlating prescription."
+      ] 
     }
   ]
 }


### PR DESCRIPTION
The goal of this PR is to add a few more example prompts that address use cases internal and external users are asking for. Namely: input-output pairs for RAG models, medical patient dataset, financial transactions data.  

Also, I added explicit requests to generate "X rows" to each example prompt. This is something we've been discussing to help prevent users from running into num_rows bug. 