### PR TITLE
Fix Tv2 model blueprint name in relational transform notebook

### DIFF
--- a/docs/notebooks/transform_relational_database.ipynb
+++ b/docs/notebooks/transform_relational_database.ipynb
@@ -236,7 +236,7 @@
         "    config:\n",
         "      project_id: {project.project_guid}\n",
         "      train:\n",
-        "        model: \"transform/v2\"\n",
+        "        model: \"transform/transform_v2\"\n",
         "        dataset: \"{{outputs.extract.dataset}}\"\n",
         "      run:\n",
         "        num_records_multiplier: 1.0\n",


### PR DESCRIPTION
Per https://github.com/gretelai/gretel-blueprints/blob/main/config_templates/gretel/transform/transform_v2.yml