### PR TITLE
Update natural-language config to Mistral

### DIFF
--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -4,11 +4,11 @@
 # using the column_name parameter
 
 schema_version: "1.0"
-name: "natural-language-gpt"
+name: "natural-language"
 models:
   - gpt_x:
       data_source: "__temp__"
-      pretrained_model: "meta-llama/Llama-2-7b-chat-hf"
+      pretrained_model: "mistralai/Mistral-7B-Instruct-v0.2"
       column_name: null
       params:
         batch_size: 4
@@ -16,7 +16,7 @@ models:
         weight_decay: 0.01
         warmup_steps: 100
         lr_scheduler: "linear"
-        learning_rate: 0.0002
+        learning_rate: 0.0001
       generate:
         num_records: 80
         maximum_text_length: 100

--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -4,7 +4,7 @@
 # using the column_name parameter
 
 schema_version: "1.0"
-name: "natural-language"
+name: "natural-language-gpt"
 models:
   - gpt_x:
       data_source: "__temp__"


### PR DESCRIPTION
Update `config_templates/gretel/synthetics/natural-language.yml`
* Use updated pretrained model `mistralai/Mistral-7B-Instruct-v0.2` 
* Lower learning rate to 1e-4  / 0.0001
  * This value was chosen using Gretel Tuner on 4 public example notebooks, maximizing for Text SQS. It is also consistent with observations from the community that fine tuning mistral 7b is more effective with a lower learning rate.
