### PR TITLE
[FEAT] INT-1898 Update JS Navigator script to allow > 50 rows

### DIFF
--- a/docs/navigator_api/js/example.js
+++ b/docs/navigator_api/js/example.js
@@ -16,7 +16,9 @@ GRETEL_API_KEY={your key} node example.js --prompt="generate a users table"
 GRETEL_API_KEY={your key} node example.js --prompt="generate a users table" --num_rows=40 \
 --model_id=gretelai/tabular-v0c --temperature=0.9 --top_k=20 --top_p=0.6
 
-3. Get output as JSON with `--json=true`. Defaults to a human-readable output.
+3. Other options:
+* Get output as JSON with `--json=true`. Defaults to a human-readable output.
+* Show intermediate logging with --showIntermediateLogging=true
 
 4. Get list of available inference models:
 
@@ -68,12 +70,15 @@ const main = async () => {
 
   let result = [];
   const rowCallback = (row) => {
-    result = result.concat(row.table_data);
-    console.log("\n--- logging intermediate results ---");
-    if (args.json) {
-      console.log(JSON.stringify(result));
-    } else {
-      console.table(result);
+    result.push(row.table_data);
+
+    if (args.showIntermediateLogging) {
+      console.log("\n--- logging intermediate results ---");
+      if (args.json) {
+        console.log(JSON.stringify(result));
+      } else {
+        console.table(result);
+      }
     }
   };
 
@@ -85,6 +90,7 @@ const main = async () => {
     params
   ).then(() => {
     console.log("---- Generation complete, final data: ----");
+
     if (args.json) {
       console.log(JSON.stringify(result));
     } else {

--- a/docs/navigator_api/js/example.js
+++ b/docs/navigator_api/js/example.js
@@ -1,8 +1,9 @@
 /*
+
 REQUIREMENTS
 1. Requires Node v18 or later
 2. Must set GRETEL_API_KEY env variable before running. Get your key from https://console.gretel.ai/users/me/key
-3. Maximum of 50 rows. Use the standard /models batch API for more.
+3. Want to generate a LOT of data? Use the standard /models batch API..
 
 EXAMPLES
 
@@ -15,11 +16,12 @@ GRETEL_API_KEY={your key} node example.js --prompt="generate a users table"
 GRETEL_API_KEY={your key} node example.js --prompt="generate a users table" --num_rows=40 \
 --model_id=gretelai/tabular-v0c --temperature=0.9 --top_k=20 --top_p=0.6
 
-3. Get output as JSON with --json=true. Defaults to a human-friendly output.
+3. Get output as JSON with `--json=true`. Defaults to a human-readable output.
 
 4. Get list of available inference models:
 
 GRETEL_API_KEY={your key} node example.js --getModels
+
 */
 
 import { getModels, createStructuredData } from "./streaming_navigator.js";

--- a/docs/navigator_api/js/example.js
+++ b/docs/navigator_api/js/example.js
@@ -67,6 +67,12 @@ const main = async () => {
   let result = [];
   const rowCallback = (row) => {
     result = result.concat(row.table_data);
+    console.log("\n--- logging intermediate results ---");
+    if (args.json) {
+      console.log(JSON.stringify(result));
+    } else {
+      console.table(result);
+    }
   };
 
   createStructuredData(
@@ -76,13 +82,14 @@ const main = async () => {
     args.model_id,
     params
   ).then(() => {
+    console.log("---- Generation complete, final data: ----");
     if (args.json) {
       console.log(JSON.stringify(result));
     } else {
       console.table(result);
     }
 
-    console.log("---- Generation complete. ----");
+    console.log("---- END. ----");
   });
 };
 

--- a/docs/navigator_api/js/example.js
+++ b/docs/navigator_api/js/example.js
@@ -70,7 +70,7 @@ const main = async () => {
 
   let result = [];
   const rowCallback = (row) => {
-    result.push(row.table_data);
+    result = result.concat(row.table_data);
 
     if (args.showIntermediateLogging) {
       console.log("\n--- logging intermediate results ---");

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -8,8 +8,7 @@ const DEFAULT_HYPERPARAMS = {
   top_p: 0.9,
 };
 
-const BASE_URL = "https://api-dev.gretel.cloud/";
-// const BASE_URL = "https://api.gretel.cloud/";
+const BASE_URL = "https://api.gretel.cloud/";
 
 ///////////////////////////////////////////////
 // Generates structured data given a prompt //

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -123,8 +123,8 @@ export const createStructuredData = async (
 
   /**
    *
-   * Since each stream allows a MAX of 50 rows, create multiple streams as needed,
-   * passing the results of the previous stream into the next stream so we don't duplicate data.
+   * Since each individual stream allows a MAX of 50 rows, create multiple streams as needed,
+   * passing partial results of the previous stream into the next stream.
    *
    */
   const recursiveStreaming = async ({
@@ -165,6 +165,7 @@ export const createStructuredData = async (
         const tableHeadersString = table_headers.join(", ");
         const table_data = results.map((row) => row.table_data).flat();
         const lastRows = table_data.slice(Math.max(table_data.length - 3, 0));
+
         try {
           return recursiveStreaming({
             numRows: numRowsLeft,

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -122,10 +122,8 @@ export const createStructuredData = async (
   };
 
   /**
-   *
    * Since each individual stream allows a MAX of 50 rows, create multiple streams as needed,
-   * passing partial results of the previous stream into the next stream.
-   *
+   * passing results of the previous stream into the next stream.
    */
   const recursiveStreaming = async ({
     numRows,
@@ -164,14 +162,13 @@ export const createStructuredData = async (
         const table_headers = results[0].table_headers;
         const tableHeadersString = table_headers.join(", ");
         const table_data = results.map((row) => row.table_data).flat();
-        const lastRows = table_data.slice(Math.max(table_data.length - 3, 0));
 
         try {
           return recursiveStreaming({
             numRows: numRowsLeft,
             prompt: `Generate more data like the following table with the columns: ${tableHeadersString}`,
             table_headers,
-            table_data: lastRows,
+            table_data,
           });
         } catch (err) {
           console.log("Error in recursive streaming", err);

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -1,6 +1,5 @@
 const MAX_ROWS_PER_STREAM = 50;
 const REQUEST_TIMEOUT_SEC = 60;
-const STREAM_SLEEP_TIME = 0.5;
 const POLLING_DELAY = 500; // ms
 // Use reasonable default params if not set
 const DEFAULT_HYPERPARAMS = {
@@ -20,95 +19,164 @@ const BASE_URL = "https://api-dev.gretel.cloud/";
  * @param {string} prompt -- text describing what you want the model to generate data about.
  * @param {function} rowCallback -- function that receives the generated data. this will be called several times, depending on how much data is requested
  * @param {number, optional} num_rows -- number of rows to generate. Defaults to 10.
- * @param {string, optional} model_id -- string id of the model (from getModels) to use to generate data. If none provided, the latest default model will be used.
+ * @param {string, optional} model_id -- string id of the model (from getModels) to use to generate data. If none provided, a default model will be used.
  * @param {object, optional} params -- hyperparameter settings. Includes: temperature, top_k, top_p.
  */
 export const createStructuredData = async (
   prompt,
   rowCallback,
   num_rows = 10,
-  model_id, // = "gretelai/tabular-v0",
+  model_id = "gretelai/tabular-v0",
   params
 ) => {
-  const { stream_id } = await createStream({
+  const createStream = async ({ model_id, num_rows, prompt, params }) => {
+    // Create stream
+    const streamResponse = await _callAPI("v1/inference/tabular/stream", {
+      model_id,
+      num_rows,
+      prompt,
+      params: { ...DEFAULT_HYPERPARAMS, ...params },
+    });
+
+    const streamResult = await streamResponse.json();
+
+    // if stream creation errored, surface to user and stop process.
+    if (streamResponse.status !== 200) {
+      console.log("Error creating stream", JSON.stringify(streamResult));
+      return;
+    }
+    return streamResult;
+  };
+
+  const readFromStream = async ({ stream_id, num_rows, iterator }) => {
+    const iterateResponse = await _callAPI(
+      "v1/inference/tabular/stream/iterate",
+      {
+        stream_id,
+        iterator,
+        count: num_rows,
+      }
+    );
+
+    const iterateResult = await iterateResponse.json();
+
+    if (iterateResponse.status !== 200) {
+      throw new Error(JSON.stringify(iterateResult));
+    } else {
+      return iterateResult;
+    }
+  };
+
+  const getDataFromStream = async ({ stream_id, num_rows, rowHandler }) => {
+    let iterator = "";
+    let resultCount = 0;
+
+    while (true) {
+      let iterateResult;
+      try {
+        iterateResult = await readFromStream({ stream_id, num_rows, iterator });
+      } catch (err) {
+        console.log(`Error iterating on stream: ${err}`);
+        break;
+      }
+
+      iterator = iterateResult.next_iterator;
+
+      for (const data of iterateResult.data) {
+        if (data.data_type === "TabularResponse") {
+          rowHandler(data.data);
+          resultCount++;
+        } else {
+          console.log(data.data);
+        }
+      }
+      if (
+        iterateResult.stream_state.status === "closed" ||
+        resultCount >= num_rows
+      ) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, POLLING_DELAY));
+    }
+  };
+
+  // Combines functions above to creates a single stream and then fetch data from that stream.
+  // Currently, each stream can return a maximum of 50 rows.
+  const createStreamAndMakeData = async ({
     model_id,
     num_rows,
     prompt,
     params,
-  });
+    rowHandler,
+  }) => {
+    const { stream_id } = await createStream({
+      model_id,
+      num_rows,
+      prompt,
+      params,
+    });
 
-  // Read from stream.
-  let iterator = "";
-  let resultCount = 0;
-  while (true) {
-    let iterateResult;
-    try {
-      iterateResult = await readFromStream({ stream_id, num_rows });
-    } catch (err) {
-      console.log(`Error iterating on stream: ${err}`);
-      break;
-    }
+    await getDataFromStream({ stream_id, num_rows, rowHandler });
+  };
 
-    iterator = iterateResult.next_iterator;
-
-    for (const data of iterateResult.data) {
-      if (data.data_type === "TabularResponse") {
-        rowCallback(data.data);
-        resultCount++;
-      } else {
-        console.log(data.data);
-      }
-    }
-    if (
-      iterateResult.stream_state.status === "closed" ||
-      resultCount >= num_rows
-    ) {
-      break;
-    }
-    await new Promise((r) => setTimeout(r, POLLING_DELAY));
-  }
-};
-
-const createStream = async ({ model_id, num_rows, prompt, params }) => {
-  // Create stream
-  const streamResponse = await _callAPI("v1/inference/tabular/stream", {
-    model_id,
-    num_rows,
+  /**
+   *
+   * Since each stream allows a MAX of 50 rows, create multiple streams as needed,
+   * passing the results of the previous stream into the next stream so we don't duplicate data.
+   *
+   */
+  const recursiveStreaming = async ({
+    numRows,
     prompt,
-    params: { ...DEFAULT_HYPERPARAMS, ...params },
-  });
-
-  const streamResult = await streamResponse.json();
-
-  // if stream creation errored, surface to user and stop process.
-  if (streamResponse.status !== 200) {
-    console.log("Error creating stream", JSON.stringify(streamResult));
-    return;
-  }
-
-  console.log("created stream:", streamResult); // logs stream id
-  return streamResult;
-};
-const readFromStream = async ({ stream_id, num_rows }) => {
-  const iterateResponse = await _callAPI(
-    "v1/inference/tabular/stream/iterate",
-    {
-      stream_id,
-      iterator,
-      count: num_rows,
-    }
-  );
-
-  const iterateResult = await iterateResponse.json();
-
-  if (iterateResponse.status !== 200) {
-    throw new Error(JSON.stringify(iterateResult));
-  } else {
+    table_headers,
+    table_data,
+  }) => {
+    let numRowsLeft = numRows;
     /**
-     * next_iterator, data, stream_state
+     * gather generated data from current streaming to pass to
+     * the next stream.
      */
-    return iterateResult;
-  }
+    let results = [];
+
+    const newRowHandler = (row) => {
+      numRowsLeft--;
+      // add to internal tracker
+      results.push(row);
+      // call external callback with current data
+      rowCallback(row);
+    };
+
+    const numRowsForStream =
+      numRows > MAX_ROWS_PER_STREAM ? MAX_ROWS_PER_STREAM : numRows;
+
+    return createStreamAndMakeData({
+      model_id,
+      num_rows: numRowsForStream,
+      prompt: prompt,
+      params,
+      table_data,
+      table_headers,
+      rowHandler: newRowHandler,
+    }).then(() => {
+      if (numRowsLeft > 0 && results.length) {
+        const table_headers = results[0].table_headers;
+        const table_data = results.map((row) => row.table_data).flat();
+
+        try {
+          return recursiveStreaming({
+            numRows: numRowsLeft,
+            prompt: "Generate more data like the following table:",
+            table_headers,
+            table_data: table_data.slice(Math.max(table_data.length - 3, 0)), // send just last 3 records
+          });
+        } catch (err) {
+          console.log("Error in recursive streaming", err);
+        }
+      }
+    });
+  };
+
+  await recursiveStreaming({ numRows: num_rows, prompt });
 };
 
 /////////////////////////////////////////////

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -31,12 +31,12 @@ export const createStructuredData = async (
   const createStream = async ({
     model_id,
     num_rows,
-    prompt,
+    prompt = "",
     table_data,
     table_headers,
     params,
   }) => {
-    const ref_data = table_headers.length
+    const ref_data = table_headers?.length
       ? { sample_data: { table_headers, table_data } }
       : undefined;
     // Create stream

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -1,45 +1,56 @@
+const MAX_ROWS_PER_STREAM = 50;
+const REQUEST_TIMEOUT_SEC = 60;
+const STREAM_SLEEP_TIME = 0.5;
+const POLLING_DELAY = 500; // ms
+// Use reasonable default params if not set
+const DEFAULT_HYPERPARAMS = {
+  temperature: 0.7,
+  top_k: 40,
+  top_p: 0.9,
+};
+
+const BASE_URL = "https://api-dev.gretel.cloud/";
+// const BASE_URL = "https://api.gretel.cloud/";
+
 ///////////////////////////////////////////////
 // Generates structured data given a prompt //
 /////////////////////////////////////////////
+/**
+ *
+ * @param {string} prompt -- text describing what you want the model to generate data about.
+ * @param {function} rowCallback -- function that receives the generated data. this will be called several times, depending on how much data is requested
+ * @param {number, optional} num_rows -- number of rows to generate. Defaults to 10.
+ * @param {string, optional} model_id -- string id of the model (from getModels) to use to generate data. If none provided, the latest default model will be used.
+ * @param {object, optional} params -- hyperparameter settings. Includes: temperature, top_k, top_p.
+ */
 export const createStructuredData = async (
   prompt,
   rowCallback,
   num_rows = 10,
-  model_id = "gretelai/tabular-v0",
+  model_id, // = "gretelai/tabular-v0",
   params
 ) => {
-  // Use reasonable default params if not set
-  params = {
-    temperature: params.temperature || 0.7,
-    top_k: params.top_k || 40,
-    top_p: params.top_p || 0.9,
-  };
-
-  // Create stream
-  const streamResponse = await _callAPI("v1/inference/tabular/stream", {
-    model_id: model_id,
-    num_rows: num_rows,
-    prompt: prompt,
-    params: params,
+  const { stream_id } = await createStream({
+    model_id,
+    num_rows,
+    prompt,
+    params,
   });
-  const streamResult = await streamResponse.json();
-  console.log(streamResult);
 
   // Read from stream.
   let iterator = "";
   let resultCount = 0;
   while (true) {
-    const iterateResponse = await _callAPI(
-      "v1/inference/tabular/stream/iterate",
-      {
-        stream_id: streamResult.stream_id,
-        iterator: iterator,
-        count: num_rows,
-      }
-    );
-    const iterateResult = await iterateResponse.json();
+    let iterateResult;
+    try {
+      iterateResult = await readFromStream({ stream_id, num_rows });
+    } catch (err) {
+      console.log(`Error iterating on stream: ${err}`);
+      break;
+    }
 
     iterator = iterateResult.next_iterator;
+
     for (const data of iterateResult.data) {
       if (data.data_type === "TabularResponse") {
         rowCallback(data.data);
@@ -54,7 +65,49 @@ export const createStructuredData = async (
     ) {
       break;
     }
-    await new Promise((r) => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, POLLING_DELAY));
+  }
+};
+
+const createStream = async ({ model_id, num_rows, prompt, params }) => {
+  // Create stream
+  const streamResponse = await _callAPI("v1/inference/tabular/stream", {
+    model_id,
+    num_rows,
+    prompt,
+    params: { ...DEFAULT_HYPERPARAMS, ...params },
+  });
+
+  const streamResult = await streamResponse.json();
+
+  // if stream creation errored, surface to user and stop process.
+  if (streamResponse.status !== 200) {
+    console.log("Error creating stream", JSON.stringify(streamResult));
+    return;
+  }
+
+  console.log("created stream:", streamResult); // logs stream id
+  return streamResult;
+};
+const readFromStream = async ({ stream_id, num_rows }) => {
+  const iterateResponse = await _callAPI(
+    "v1/inference/tabular/stream/iterate",
+    {
+      stream_id,
+      iterator,
+      count: num_rows,
+    }
+  );
+
+  const iterateResult = await iterateResponse.json();
+
+  if (iterateResponse.status !== 200) {
+    throw new Error(JSON.stringify(iterateResult));
+  } else {
+    /**
+     * next_iterator, data, stream_state
+     */
+    return iterateResult;
   }
 };
 
@@ -63,6 +116,9 @@ export const createStructuredData = async (
 ///////////////////////////////////////////
 export const getModels = async () => {
   const response = await _callAPI("v1/inference/models", null, "GET");
+  if (response.status !== 200) {
+    return `Unable to fetch models: ${response.stausText}`;
+  }
   return response.json();
 };
 
@@ -70,16 +126,17 @@ export const getModels = async () => {
 // Internal //
 //////////////
 const _callAPI = (url, body, method = "POST") => {
-  const BASE_URL = "https://api.gretel.cloud/";
   const req = {
-    method: method,
+    method,
     headers: {
       "Content-Type": "application/json",
       Authorization: process.env.GRETEL_API_KEY,
     },
   };
+
   if (method === "POST" && body) {
     req.body = JSON.stringify(body);
   }
+
   return fetch(BASE_URL + url, req);
 };

--- a/docs/navigator_api/js/streaming_navigator.js
+++ b/docs/navigator_api/js/streaming_navigator.js
@@ -31,7 +31,7 @@ export const createStructuredData = async (
   const createStream = async ({
     model_id,
     num_rows,
-    prompt = "",
+    prompt,
     table_data,
     table_headers,
     params,
@@ -173,6 +173,7 @@ export const createStructuredData = async (
         try {
           return recursiveStreaming({
             numRows: numRowsLeft,
+            prompt,
             table_headers: results[0].table_headers,
             table_data: results.map((row) => row.table_data).flat(),
           });


### PR DESCRIPTION
## Problem
We have an example script in JavaScript for using the Navigator APIs to generate data. It only enables the ability to create one stream at a time, therefore limiting the user to a maximum of 50 rows of data fetching per call. 

## Solution
We've written some Python code to facilitate calling more than 50 rows, so let's do it for JS, too. This diff updates the JS "sdk" to create multiple streams sequentially as needed to fulfill the requested number of rows. This includes passing the results of the previous stream into the new stream to facilitate data generation.

## Additional Info
I refactored the existing code a bit to pull out some sub-functions and generally tidy a few things. I also added the ability to output the data as json rather than as the table, since users might want to copy the data for use elsewhere. Try `--json=true` for that functionality.

## Testing
Pull this down locally. Get your API key (note: either use prod environment or update the `BASE_URL` to the dev environment). To see it create and use multiple streams, pass a `num_rows` > 50, such as:

```
GRETEL_API_KEY={your key} node example.js --prompt="generate a table of cat names and their favorite toys" --num_rows=52
```