### PR TITLE
[FIX] INT-2168 Transform V1 no longer default.yml, update pointers

### DIFF
--- a/config_templates/gretel/transform/default.yml
+++ b/config_templates/gretel/transform/default.yml
@@ -1,29 +1,31 @@
 # Policy to search for and redact "sensitive PII" as defined by `ask-experian` as well as
-# a custom defined regular expression for user IDs. 
+# a custom defined regular expression for user IDs.
 # https://www.experian.com/blogs/ask-experian/what-is-personally-identifiable-information/
 
-# NLP is turned on using "use_nlp: true" to provide better person name and 
-# location detection. Set to false if you're experiencing performance issues
-# https://docs.gretel.ai/classify/classify-model-configuration#classifying-data-using-nlp
-
 schema_version: "1.0"
-name: "redact-pii-nlp-on"
+name: "redact-pii-nlp"
 models:
-  - transforms:
+  - transform_v2:
       data_source: "_"
-      use_nlp: true
-      policies:
-        - name: remove_pii
-          rules:
-            - name: fake_or_redact_pii
-              conditions:
-                value_label:
-                  - person_name
-                  - credit_card_number
-                  - phone_number
-                  - email_address
-                  - us_social_security_number
-                  - location
-              transforms:
-                - type: fake
-                - type: hash
+      globals:
+        classify:
+          # Classification currently uses the Gretel Cloud. If you are running in a hybrid
+          # environment and prefer not to use the Cloud, please set "enable: false" below.
+          enable: true
+          entities:
+            - name
+            - email
+            - phone_number
+            - address
+            - credit_card_number
+            - ssn
+          ner_threshold: 0.2
+        locales: [en_US, en_CA]
+      steps:
+        - rows:
+            update:
+              - condition: column.entity is in globals.classify.entities
+                value: column.entity | fake
+                fallback_value: '"<" ~ column.entity ~ ">"'
+              - type: text
+                value: this | fake_entities

--- a/config_templates/gretel/transform/transform-v1-default.yml
+++ b/config_templates/gretel/transform/transform-v1-default.yml
@@ -1,0 +1,29 @@
+# Policy to search for and redact "sensitive PII" as defined by `ask-experian` as well as
+# a custom defined regular expression for user IDs.
+# https://www.experian.com/blogs/ask-experian/what-is-personally-identifiable-information/
+
+# NLP is turned on using "use_nlp: true" to provide better person name and
+# location detection. Set to false if you're experiencing performance issues
+# https://docs.gretel.ai/classify/classify-model-configuration#classifying-data-using-nlp
+
+schema_version: "1.0"
+name: "redact-pii-nlp-on"
+models:
+  - transforms:
+      data_source: "_"
+      use_nlp: true
+      policies:
+        - name: remove_pii
+          rules:
+            - name: fake_or_redact_pii
+              conditions:
+                value_label:
+                  - person_name
+                  - credit_card_number
+                  - phone_number
+                  - email_address
+                  - us_social_security_number
+                  - location
+              transforms:
+                - type: fake
+                - type: hash

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -108,7 +108,7 @@
     {
       "modelType": "transform_v2",
       "modelCategory": "transform",
-      "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
+      "defaultConfig": "config_templates/gretel/transform/default.yml",
       "description": "Flexible data pre and post processing toolkit including support for detecting arbitrary PII entities, configurable data generation templates, and faster speed.",
       "label": "Transform V2",
       "sampleDataset": {

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -123,7 +123,7 @@
     {
       "modelType": "transform",
       "modelCategory": "transform",
-      "defaultConfig": "config_templates/gretel/transform/default.yml",
+      "defaultConfig": "config_templates/gretel/transform/transform-v1-default.yml",
       "description": "Detect and transform PII entities in datasets, including named entity recognition within free text fields.",
       "label": "Transform",
       "sampleDataset": {

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -108,7 +108,7 @@
     {
       "modelType": "transform_v2",
       "modelCategory": "transform",
-      "defaultConfig": "config_templates/gretel/transform/default.yml",
+      "defaultConfig": "config_templates/gretel/transform/transform_v2.yml",
       "description": "Flexible data pre and post processing toolkit including support for detecting arbitrary PII entities, configurable data generation templates, and faster speed.",
       "label": "Transform V2",
       "sampleDataset": {

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -329,7 +329,7 @@
       "icon": "transform.png",
       "modelType": "transform",
       "modelCategory": "transform",
-      "defaultConfig": "config_templates/gretel/transform/default.yml",
+      "defaultConfig": "config_templates/gretel/transform/transform-v1-default.yml",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
         "description": "Unstructured text datasets are useful for training chatbots or other models that need large amounts of data. The emails in this public dataset need to be de-identified before they can be used to train ML models.",

--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -327,9 +327,9 @@
       "description": "Use Named Entity Recognition (NER) to detect and redact personally identifiable data in free text fields.",
       "cardType": "Console",
       "icon": "transform.png",
-      "modelType": "transform",
+      "modelType": "transform_v2",
       "modelCategory": "transform",
-      "defaultConfig": "config_templates/gretel/transform/transform-v1-default.yml",
+      "defaultConfig": "config_templates/gretel/transform/default.yml",
       "sampleDataset": {
         "fileName": "sample-transform-emails.csv",
         "description": "Unstructured text datasets are useful for training chatbots or other models that need large amounts of data. The emails in this public dataset need to be de-identified before they can be used to train ML models.",


### PR DESCRIPTION
## Problem
The `transform/default.yml` was updated to be a transform v2 yaml. However, various transform v1 resources still pointed to it, causing some confusion.

## Solution
Create a transform-v1-default, which is just the old tv1 config. Update those v1 resources to point to it instead of the new `default`. The default file itself was only updated on `main` and not here in `develop`, too, so I've backfilled that change to have our development environment more accurately reflect production.