### PR TITLE
PLAT-2174: Use `gretelai/gpt-auto` as pretrained_model for natural language gpt template

### DIFF
--- a/config_templates/gretel/synthetics/natural-language-differential-privacy.yml
+++ b/config_templates/gretel/synthetics/natural-language-differential-privacy.yml
@@ -17,7 +17,7 @@ name: "natural-language-dp"
 models:
   - gpt_x:
       data_source: "__temp__" 
-      pretrained_model: "gretelai/gpt-auto"
+      pretrained_model: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
       column_name: null  # Specify column name for data if using multiple columns
       params:
         batch_size: 16  # Number of samples used to compute gradient

--- a/config_templates/gretel/synthetics/natural-language-differential-privacy.yml
+++ b/config_templates/gretel/synthetics/natural-language-differential-privacy.yml
@@ -17,7 +17,7 @@ name: "natural-language-dp"
 models:
   - gpt_x:
       data_source: "__temp__" 
-      pretrained_model: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+      pretrained_model: "gretelai/gpt-auto"
       column_name: null  # Specify column name for data if using multiple columns
       params:
         batch_size: 16  # Number of samples used to compute gradient

--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -8,7 +8,7 @@ name: "natural-language-gpt"
 models:
   - gpt_x:
       data_source: "__temp__"
-      pretrained_model: "mistralai/Mistral-7B-Instruct-v0.2"
+      pretrained_model: "gretelai/gpt-auto"
       column_name: null
       params:
         batch_size: 4


### PR DESCRIPTION
@alexahaushalter, @matthewgrossman, @stefan-kickoff, @pimlock Should Natural Language Differentially Private Fine-Tuning Configuration have its `TinyLlama/TinyLlama-1.1B-Chat-v1.0`? It has a much smaller model execution time, switching to `gpt-auto` led from 3 minutes to 22 minutes. It also gave a smaller `Synthetic Quality Score` (19 Very Poor vs 20 Poor), which might not be a problem


<img width="1248" alt="image" src="https://github.com/user-attachments/assets/3545e2ac-e1cf-40ca-82d3-8b0a8e824fe4">
