### PR TITLE
INT-2510 Remove "Evaluate" from modelTypesList.json

### DIFF
--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -149,21 +149,6 @@
         "trainingTime": "< 1 min",
         "bytes": 15996
       }
-    },
-    {
-      "modelType": "evaluate",
-      "modelCategory": "synthetics",
-      "defaultConfig": "config_templates/gretel/synthetics/tabular-lstm-evaluate.yml",
-      "description": "Synthesizes data and validates it for downstream models using comprehensive quality and utility reporting.",
-      "label": "Evaluate",
-      "sampleDataset": {
-        "fileName": "bank_marketing_small.csv",
-        "description": "Create synthetic data based on the publicly available dataset predicting opting in or out of bank marketing.",
-        "records": 4521,
-        "fields": 17,
-        "trainingTime": "< 10 mins",
-        "bytes": 371020
-      }
     }
   ]
 }


### PR DESCRIPTION
# Problem
We realized while investigating a bug report that Evaluate as a standalone model type does not necessarily add much value - after much discussion on slack the decision was made to remove Evaluate from the model types list. (This decision can be found in #gretel-workflows-and-connectors)

# Solution
Removing the evaluate entry from the modeType array on the modelTypesList.json

# Testing
Served blueprints locally (npx http-server --cors), pointed my local development Console to that blueprint instance (changing GRETEL_BLUEPRINTS_URL) and ensured that "Evaluate" did NOT show up on the Model tile (dropdown) and it also did NOT show on the start from scratch flow on the "Select a Model" step.