### PR TITLE
[INT-2348] Sample config files for differential privacy

### DIFF
--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -4,6 +4,7 @@
       "modelType": "navigator_ft",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/navigator-ft.yml",
+      "differentialPrivacyConfig": "config_templates/gretel/synthetics/navigator-ft-differential-privacy.yml",
       "description": "Our newest language model capable of generating multi-modal tabular data including mixed categorical, numeric, time-series, and free text fields.",
       "label": "Navigator Fine Tuning",
       "sampleDataset": {

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -20,6 +20,7 @@
       "modelType": "actgan",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/tabular-actgan.yml",
+      "differentialPrivacyConfig": "config_templates/gretel/synthetics/tabular-differential-privacy.yml",
       "description": "Our speediest and most efficient GAN model for generating highly dimensional numeric and categorical tabular data.",
       "label": "Synthetic ACTGAN",
       "sampleDataset": {

--- a/model_types/modelTypesList.json
+++ b/model_types/modelTypesList.json
@@ -34,6 +34,7 @@
       "modelType": "gpt_x",
       "modelCategory": "synthetics",
       "defaultConfig": "config_templates/gretel/synthetics/natural-language.yml",
+      "differentialPrivacyConfig": "config_templates/gretel/synthetics/natural-language-differential-privacy.yml",
       "description": "GPT3-like pre-trained transformer model for generating natural language text from an input file.",
       "label": "GPT",
       "sampleDataset": {


### PR DESCRIPTION
# Problem

NavFT will soon support differential-privacy while we have some sample configuration files for this, they are hidden away from use-cases.

Blueprints in Console is attempting to expose differential privacy configs and adding a new field is the most efficient way to solve for this.