### PR TITLE
Fix whitespace diffs between develop and main

### DIFF
--- a/config_templates/gretel/synthetics/low-record-count.yml
+++ b/config_templates/gretel/synthetics/low-record-count.yml
@@ -4,17 +4,17 @@ schema_version: "1.0"
 name: "low-record-count"
 models:
   - actgan:
-        data_source: __tmp__
-        params:
-            epochs: auto
-            generator_dim: [1024, 1024]
-            discriminator_dim: [1024, 1024]
-            generator_lr: 0.0001
-            discriminator_lr: .00033
-            batch_size: auto
-            auto_transform_datetimes: False
-        generate:
-            num_records: 5000
-        privacy_filters:
-            outliers: null # Set to "auto" for additional protections
-            similarity: null # Set to "auto" for additional protections
+      data_source: __tmp__
+      params:
+        epochs: auto
+        generator_dim: [1024, 1024]
+        discriminator_dim: [1024, 1024]
+        generator_lr: 0.0001
+        discriminator_lr: .00033
+        batch_size: auto
+        auto_transform_datetimes: False
+      generate:
+        num_records: 5000
+      privacy_filters:
+        outliers: null # Set to "auto" for additional protections
+        similarity: null # Set to "auto" for additional protections


### PR DESCRIPTION
#295 included some whitespace formatting when merging to `main`, this PR makes those changes in the `develop` branch to reduce diffs between `main` and `develop`.