### PR TITLE
Fixing NavFT+DP blueprint details on gretel.json after replacing sample data

### DIFF
--- a/use_cases/gretel.json
+++ b/use_cases/gretel.json
@@ -98,8 +98,8 @@
         "description": "This dataset contains reviews, ratings, and categories for women's clothing.",
         "records": 20641,
         "fields": 8,
-        "trainingTime": "25 mins",
-        "bytes": 7137167
+        "trainingTime": "39 mins",
+        "bytes": 3260007
       }
     },
     {


### PR DESCRIPTION
In our most recent run it took 39min for the experiment to complete. I think 25min referred to the notebook version that generated only 1000 samples.