### PR TITLE
Update code notebooks to for new `data_config` option

### DIFF
--- a/docs/notebooks/demo/navigator/navigator-data-designer-sdk-text-to-python.ipynb
+++ b/docs/notebooks/demo/navigator/navigator-data-designer-sdk-text-to-python.ipynb
@@ -46,7 +46,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "1k5NjjtzPQJi"
+    "id": "1k5NjjtzPQJi",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -78,7 +79,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "0cxx8ensOqLl"
+    "id": "0cxx8ensOqLl",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -146,6 +148,10 @@
     "            * Complexity & Concepts: The code should be written at a {code_complexity} level, making use use of concepts such as {code_concept}.\n",
     "      llm_type: code\n",
     "      columns_to_list_in_prompt: [topic]\n",
+    "      data_config:\n",
+    "          type: code\n",
+    "          params:\n",
+    "            syntax: python\n",
     "\n",
     "post_processors:\n",
     "    - validator: code\n",
@@ -179,7 +185,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Ef8Ws90cPbIu"
+    "id": "Ef8Ws90cPbIu",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -190,7 +197,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Y5I2GjczNh_s"
+    "id": "Y5I2GjczNh_s",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -217,7 +225,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "fAWaJKnAP8ZJ"
+    "id": "fAWaJKnAP8ZJ",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -239,7 +248,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "VziAxDPtQEes"
+    "id": "VziAxDPtQEes",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -250,7 +260,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "dY1XI8q-Ru4z"
+    "id": "dY1XI8q-Ru4z",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -262,7 +273,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "fDAG5KmQeQ0m"
+    "id": "fDAG5KmQeQ0m",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -273,12 +285,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "y4joRe9aJZCM"
+    "id": "y4joRe9aJZCM",
+    "tags": []
    },
    "outputs": [],
    "source": [
     "path = batch_job.download_evaluation_report(wait_for_completion=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -288,7 +308,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -302,9 +322,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/notebooks/demo/navigator/navigator-data-designer-sdk-text-to-sql.ipynb
+++ b/docs/notebooks/demo/navigator/navigator-data-designer-sdk-text-to-sql.ipynb
@@ -46,7 +46,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "1k5NjjtzPQJi"
+    "id": "1k5NjjtzPQJi",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -73,7 +74,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "0cxx8ensOqLl"
+    "id": "0cxx8ensOqLl",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -163,6 +165,10 @@
     "        * Response Formatting: Exclude any markers or similar formatting cues in the instruction.\n",
     "    columns_to_list_in_prompt: [industry_sector, topic, sql_prompt, sql_task_type]\n",
     "    llm_type: code\n",
+    "    data_config:\n",
+    "      type: code\n",
+    "      params:\n",
+    "        syntax: sql\n",
     "  \n",
     "  - name: sql\n",
     "    generation_prompt: >-\n",
@@ -177,6 +183,10 @@
     "        * Complexity & Concepts: The SQL should be written at a {sql_complexity} level, making use use of concepts such as {sql_context}.\n",
     "    columns_to_list_in_prompt: [sql_prompt, sql_context, sql_complexity]\n",
     "    llm_type: code\n",
+    "    data_config:\n",
+    "      type: code \n",
+    "      params:\n",
+    "        syntax: sql\n",
     "\n",
     "post_processors:\n",
     "  - validator: code\n",
@@ -198,7 +208,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "ApZ7xb8dPOO0"
+    "id": "ApZ7xb8dPOO0",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -224,7 +235,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "7N_VqvICN9In"
+    "id": "7N_VqvICN9In",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -235,7 +247,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "7zwFpB24ZAHf"
+    "id": "7zwFpB24ZAHf",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -246,7 +259,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "4LDG93_KOcF2"
+    "id": "4LDG93_KOcF2",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -272,7 +286,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Ef8Ws90cPbIu"
+    "id": "Ef8Ws90cPbIu",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -282,7 +297,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "preview.dataset"
@@ -301,7 +318,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "nSMFirnBMXtb"
+    "id": "nSMFirnBMXtb",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -313,7 +331,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "preview.dataset"
@@ -336,7 +356,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "VziAxDPtQEes"
+    "id": "VziAxDPtQEes",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -347,7 +368,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "zRIrNifpj5vO"
+    "id": "zRIrNifpj5vO",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -359,7 +381,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "fDAG5KmQeQ0m"
+    "id": "fDAG5KmQeQ0m",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -370,12 +393,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "0I9rT4mNOLTh"
+    "id": "0I9rT4mNOLTh",
+    "tags": []
    },
    "outputs": [],
    "source": [
     "path = batch_job.download_evaluation_report(wait_for_completion=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -384,7 +415,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -398,9 +429,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## Description

The latest `gretel_client` release adds the `data_config` option to column generation tasks in `DataDesigner`. This PR updates the text-to-code example notebooks to use this new configuration setting. Otherwise, they revert to using raw text generation. 