### PR TITLE
[INT-2820] Removes the call to press the RUN button

### DIFF
--- a/use_cases/details/tabular-ft.md
+++ b/use_cases/details/tabular-ft.md
@@ -1,6 +1,6 @@
 ![Synthesize data with Tabular Fine-Tuning](https://blueprints.gretel.cloud/use_cases/images/tabular-ft.png "Synthesize data with Tabular Fine-Tuning")
 
-If you’re new to Gretel, our Tabular Fine-Tuning blueprint is a great place to start. This blueprint automatically selects our comprehensive multi-modal model, a great one-stop shop for most synthetic data generation needs. Just answer a few questions, review the model configuration and hit **Run**.
+If you’re new to Gretel, our Tabular Fine-Tuning blueprint is a great place to start. This blueprint automatically selects our comprehensive multi-modal model, a great one-stop shop for most synthetic data generation needs.
 
 Tabular Fine-Tuning supports mutliple tabular modalities of data within a single model, such as numeric, categorical, and free text data.
 

--- a/use_cases/details/tabular-gan.md
+++ b/use_cases/details/tabular-gan.md
@@ -1,6 +1,6 @@
 ![Generate synthetic tabular data](https://blueprints.gretel.cloud/use_cases/images/tabular-gan.png "Generate synthetic tabular data")
 
-The synthetic data blueprint is a great introduction to synthetic data generation using our [Tabular GAN model](https://gretel.ai/blog/scale-synthetic-data-to-millions-of-rows-with-actgan) for numeric and categorical data using a sample healthcare dataset. Just answer a few questions, review the model configuration and hit **Run**.
+The synthetic data blueprint is a great introduction to synthetic data generation using our [Tabular GAN model](https://gretel.ai/blog/scale-synthetic-data-to-millions-of-rows-with-actgan) for numeric and categorical data using a sample healthcare dataset.
 
 Prefer coding? Check out the [Gretel 101 notebook](https://colab.research.google.com/github/gretelai/gretel-blueprints/blob/main/sdk_blueprints/Gretel_101_Blueprint.ipynb) example. Synthesize data in just 4 lines of code!
 


### PR DESCRIPTION
1. Remove this line from the TabFT blueprints markdown [.../tabular-ft.md](https://github.com/gretelai/gretel-blueprints/blob/main/use_cases/details/tabular-ft.md) because it doesn’t make sense in the context of the Builder blueprints flow. Just answer a few questions, review the model configuration and hit **Run**.
2. Remove the same line from TabGAN blueprints markdown [.../tabular-gan.md](https://github.com/gretelai/gretel-blueprints/blob/main/use_cases/details/tabular-gan.md). Just answer a few questions, review the model configuration and hit Run.

Please update in both Dev (here) & Main (todo).