### PR TITLE
[INTERNAL] RDS-1527: changing defaults so that model params and blueprints match

### DIFF
--- a/config_templates/gretel/synthetics/natural-language-differential-privacy.yml
+++ b/config_templates/gretel/synthetics/natural-language-differential-privacy.yml
@@ -36,5 +36,5 @@ models:
         epsilon: 5  # Privacy budget (lower values = stronger privacy)
         delta: auto  # Probability of privacy leakage (auto-calculated)
       generate:
-        num_records: 80  # Number of records to generate
+        num_records: 1000  # Number of records to generate
         maximum_text_length: 128  # Maximum length of generated texts in tokens

--- a/config_templates/gretel/synthetics/natural-language.yml
+++ b/config_templates/gretel/synthetics/natural-language.yml
@@ -17,6 +17,7 @@ models:
         warmup_steps: 100
         lr_scheduler: "linear"
         learning_rate: 0.0001
+        max_tokens: 128
       generate:
-        num_records: 80
-        maximum_text_length: 100
+        num_records: 1000
+        maximum_text_length: 128

--- a/config_templates/gretel/synthetics/tabular-actgan.yml
+++ b/config_templates/gretel/synthetics/tabular-actgan.yml
@@ -14,7 +14,7 @@ models:
             batch_size: auto
             auto_transform_datetimes: False
         generate:
-            num_records: 5000
+            num_records: 1000
         privacy_filters:
             outliers: null # Set to "auto" for additional protections
             similarity: null # Set to "auto" for additional protections

--- a/config_templates/gretel/tasks/text_ft__default.yaml
+++ b/config_templates/gretel/tasks/text_ft__default.yaml
@@ -12,6 +12,7 @@ task:
         warmup_steps: 100
         lr_scheduler: "linear"
         learning_rate: 0.0001
+        max_tokens: 128
     generate:
       num_records: 1000
-      maximum_text_length: 100
+      maximum_text_length: 128

--- a/config_templates/gretel/workflows/tabular-gan.yml
+++ b/config_templates/gretel/workflows/tabular-gan.yml
@@ -21,7 +21,7 @@ steps:
           batch_size: auto
           auto_transform_datetimes: False
       generate:
-        num_records: 5000
+        num_records: 1000
   - name: evaluate
     task: evaluate_safe_synthetics_dataset
     inputs:

--- a/config_templates/gretel/workflows/text-ft.yml
+++ b/config_templates/gretel/workflows/text-ft.yml
@@ -20,9 +20,10 @@ steps:
           warmup_steps: 100
           lr_scheduler: "linear"
           learning_rate: 0.0001
+          max_tokens: 128
       generate:
         num_records: 1000
-        maximum_text_length: 100
+        maximum_text_length: 128
   - name: evaluate
     task: evaluate_safe_synthetics_dataset
     inputs:


### PR DESCRIPTION
1. num_records is always 1000 in all task defaults; in param defaults, it is 5000 for TabFT/TabGAN and 10 for TextFT. Recommendation - set param defaults to 1000 in all cases (this might be slow for TextFT though!)
2. for TextFT, steps is 750 for the task default; in param defaults, both steps and epochs are empty. I think this is fine - we need to be opinionated about some params in task default, but not necessarily in param defaults
3. for TextFT, generate.maximum_text_length is 100 in task default and 42 in param default. Also, train.max_tokens is 512 in param default (and empty in task default). Recommendation - set all of these to 128. This is still relatively short, but at least wouldn't affect runtime too much.
4. for TabGAN, there's a mismatch in almost all parameters: generator_dim and discriminator_dim are 1024x1024 in task and 256x256 in param; generator_lr and discriminator_lr are 2e-4/2e-4 in task and 1e-4, 3.3e-4 in param; epochs is auto in task and 600 in param; batch_size is auto in task and 500 in param. Recommendation - make params all equal to task.